### PR TITLE
Fix double return in __APPLE__ build introduced in initial porting

### DIFF
--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -342,8 +342,9 @@ int SystemProcessInterface::SystemProcesses::system_processes(SystemProcess** sy
   *system_processes = next;
 
   return OS_OK;
-#endif
+#else
   return FUNCTIONALITY_NOT_IMPLEMENTED;
+#endif
 }
 
 int SystemProcessInterface::system_processes(SystemProcess** system_procs, int* no_of_sys_processes) const {


### PR DESCRIPTION
effort.

Noticed while reviewing other changes.