### PR TITLE
Remove `bool is_MP` from _Atomic_cmpxchg_long in bsd x86 32bit (i386) 

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/atomic_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/atomic_bsd_x86.hpp
@@ -136,7 +136,7 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T exchange_value,
 
 extern "C" {
   // defined in bsd_x86.s
-  int64_t _Atomic_cmpxchg_long(int64_t, volatile int64_t*, int64_t, bool);
+  int64_t _Atomic_cmpxchg_long(int64_t, volatile int64_t*, int64_t);
   void _Atomic_move_long(const volatile int64_t* src, volatile int64_t* dst);
 }
 

--- a/src/hotspot/os_cpu/bsd_x86/bsd_x86_32.s
+++ b/src/hotspot/os_cpu/bsd_x86/bsd_x86_32.s
@@ -635,8 +635,7 @@ mmx_acs_CopyLeft:
 
         # Support for int64_t Atomic::cmpxchg(int64_t exchange_value,
         #                                     volatile int64_t* dest,
-        #                                     int64_t compare_value,
-        #                                     bool is_MP)
+        #                                     int64_t compare_value)
         #
         .p2align 4,,15
         ELF_TYPE(_Atomic_cmpxchg_long,@function)
@@ -649,10 +648,7 @@ SYMBOL(_Atomic_cmpxchg_long):
         movl     24(%esp), %eax    # 24(%esp) : compare_value (low)
         movl     28(%esp), %edx    # 28(%esp) : compare_value (high)
         movl     20(%esp), %edi    # 20(%esp) : dest
-        cmpl     $0, 32(%esp)      # 32(%esp) : is_MP
-        je       1f
-        lock
-1:      cmpxchg8b (%edi)
+        lock cmpxchg8b (%edi)
         popl     %edi
         popl     %ebx
         ret

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -786,7 +786,7 @@ inline T Atomic::cmpxchg_using_helper(Fn fn,
   return PrimitiveConversions::cast<T>(
     fn(PrimitiveConversions::cast<Type>(exchange_value),
        reinterpret_cast<Type volatile*>(dest),
-       PrimitiveConversions::cast<Type>(compare_value), fn));
+       PrimitiveConversions::cast<Type>(compare_value)));
 }
 
 template<typename T>


### PR DESCRIPTION
which was missed in:

    8169061: Drop os::is_MP checks from Atomics
    https://hg.openjdk.java.net/jdk10/jdk10/hotspot/rev/ae91ec8b554a#l2.128

and revert change in Atomic::cmpxchg_using_helper.

See https://github.com/battleblow/openjdk-jdk11u/pull/4/files#r267178160
for additional details.