### PR TITLE
x86 changes for OpenBSD/i386

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -158,7 +158,7 @@ $(eval $(call SetupNativeCompilation, BUILD_LIBJVM, \
     CFLAGS := $(JVM_CFLAGS), \
     vm_version.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     arguments.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
-    DISABLED_WARNINGS_clang := tautological-compare, \
+    DISABLED_WARNINGS_clang := tautological-compare switch, \
     DISABLED_WARNINGS_solstudio := $(DISABLED_WARNINGS_solstudio), \
     DISABLED_WARNINGS_xlc := 1540-0216 1540-0198 1540-1090 1540-1639 \
         1540-1088 1500-010, \

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1271,7 +1271,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
     movptr(obj_reg, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()));
 
     // Free entry
-    movptr(Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()), (int32_t)NULL_WORD);
+    movptr(Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()), LP64_ONLY((int32_t))NULL_WORD);
 
     if (UseBiasedLocking) {
       biased_locking_exit(obj_reg, header_reg, done);

--- a/src/hotspot/cpu/x86/interp_masm_x86.hpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.hpp
@@ -168,7 +168,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void empty_expression_stack() {
     movptr(rsp, Address(rbp, frame::interpreter_frame_monitor_block_top_offset * wordSize));
     // NULL last_sp until next java call
-    movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), (int32_t)NULL_WORD);
+    movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), LP64_ONLY((int32_t))NULL_WORD);
     NOT_LP64(empty_FPU_stack());
   }
 

--- a/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
+++ b/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
@@ -131,8 +131,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
     case T_BYTE:    slow_case_addr = jni_GetByteField_addr();    break;
     case T_CHAR:    slow_case_addr = jni_GetCharField_addr();    break;
     case T_SHORT:   slow_case_addr = jni_GetShortField_addr();   break;
-    case T_INT:     slow_case_addr = jni_GetIntField_addr();     break;
-    default:                                                     break;
+    case T_INT:     slow_case_addr = jni_GetIntField_addr();
   }
   // tail call
   __ jump (ExternalAddress(slow_case_addr));
@@ -148,7 +147,6 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   case T_CHAR:    jni_fast_GetCharField_fp    = (GetCharField_t)    fast_entry; break;
   case T_SHORT:   jni_fast_GetShortField_fp   = (GetShortField_t)   fast_entry; break;
   case T_INT:     jni_fast_GetIntField_fp     = (GetIntField_t)     fast_entry; break;
-  default:                                                                      break;
   }
   return os::win32::fast_jni_accessor_wrapper(type);
 #endif

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -460,11 +460,11 @@ void MacroAssembler::print_state32(int rdi, int rsi, int rbp, int rsp, int rbx, 
   // Print some words near top of staack.
   int* dump_sp = (int*) rsp;
   for (int col1 = 0; col1 < 8; col1++) {
-    tty->print("(rsp+0x%03x) 0x%08x: ", (int)((intptr_t)dump_sp - (intptr_t)rsp), (intptr_t)dump_sp);
+    tty->print("(rsp+0x%03x) " INTPTR_FORMAT ": ", (int)((intptr_t)dump_sp - (intptr_t)rsp), (intptr_t)dump_sp);
     os::print_location(tty, *dump_sp++);
   }
   for (int row = 0; row < 16; row++) {
-    tty->print("(rsp+0x%03x) 0x%08x: ", (int)((intptr_t)dump_sp - (intptr_t)rsp), (intptr_t)dump_sp);
+    tty->print("(rsp+0x%03x) " INTPTR_FORMAT ": ", (int)((intptr_t)dump_sp - (intptr_t)rsp), (intptr_t)dump_sp);
     for (int col = 0; col < 8; col++) {
       tty->print(" 0x%08x", *dump_sp++);
     }

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2248,7 +2248,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   if (!is_critical_native) {
     // reset handle block
     __ movptr(rcx, Address(thread, JavaThread::active_handles_offset()));
-    __ movl(Address(rcx, JNIHandleBlock::top_offset_in_bytes()), NULL_WORD);
+    __ movl(Address(rcx, JNIHandleBlock::top_offset_in_bytes()), (int32_t)NULL_WORD);
 
     // Any exception pending?
     __ cmpptr(Address(thread, in_bytes(Thread::pending_exception_offset())), (int32_t)NULL_WORD);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -2741,7 +2741,7 @@ class StubGenerator: public StubCodeGenerator {
     __ jcc(Assembler::equal, L_key256_top);
 
     //key128 begins here
-    __ movptr(pos, 0); // init pos before L_multiBlock_loopTop
+    __ movptr(pos, NULL_WORD); // init pos before L_multiBlock_loopTop
 
 #define CTR_DoFour(opc, src_reg)               \
     __ opc(xmm_result0, src_reg);              \
@@ -2907,11 +2907,11 @@ class StubGenerator: public StubCodeGenerator {
     __ ret(0);
 
     __ BIND (L_key192_top);
-    __ movptr(pos, 0); // init pos before L_multiBlock_loopTop
+    __ movptr(pos, NULL_WORD); // init pos before L_multiBlock_loopTop
     __ jmp(L_multiBlock_loopTop[1]); //key192
 
     __ BIND (L_key256_top);
-    __ movptr(pos, 0); // init pos before L_multiBlock_loopTop
+    __ movptr(pos, NULL_WORD); // init pos before L_multiBlock_loopTop
     __ jmp(L_multiBlock_loopTop[2]); //key192
 
     return start;

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -202,7 +202,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   // Restore stack bottom in case i2c adjusted stack
   __ movptr(rsp, Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize));
   // and NULL it as marker that esp is now tos until next java call
-  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), (int32_t)NULL_WORD);
+  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), LP64_ONLY((int32_t))NULL_WORD);
 
   __ restore_bcp();
   __ restore_locals();
@@ -250,7 +250,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state, i
 #endif // _LP64
 
   // NULL last_sp until next java call
-  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), (int32_t)NULL_WORD);
+  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), LP64_ONLY((int32_t))NULL_WORD);
   __ restore_bcp();
   __ restore_locals();
   const Register thread = NOT_LP64(rcx) LP64_ONLY(r15_thread);
@@ -1509,7 +1509,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   Interpreter::_rethrow_exception_entry = __ pc();
   // Restore sp to interpreter_frame_last_sp even though we are going
   // to empty the expression stack for the exception processing.
-  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), (int32_t)NULL_WORD);
+  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), LP64_ONLY((int32_t))NULL_WORD);
   // rax: exception
   // rdx: return address/pc that threw exception
   __ restore_bcp();    // r13/rsi points to call/send
@@ -1655,7 +1655,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 
   // Restore the last_sp and null it out
   __ movptr(rsp, Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize));
-  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), (int32_t)NULL_WORD);
+  __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), LP64_ONLY((int32_t))NULL_WORD);
 
   __ restore_bcp();
   __ restore_locals();


### PR DESCRIPTION
For the jniFastGetField_x86_32.cpp change, this favors suppressing compiler specific warnings over changing shared code. IMO, the less required code changes in the bsd-port branch the better – easier to merge upstream changes into bsd-port branch and/or be merged upstream in the future.

For the macroAssembler_x86.cpp change, flags-cflags.m4 specifically adds -Wformat=2 to the jvm build so suppressing format specifier warnings for clang seems like the wrong thing to do in this case. 

On x86_32 (i386), both Apple and OpenBSD define intptr_t to a type that is different than int32_t (same size but not the same type). This leads to places in hotspot where the x86_32 build needs adjusting because int32_t can’t be implicitly converted to intptr_t. I’ve fixed a bunch of these before and when Apple came on board those changes made it upstream, but it looks like Apple isn’t building the JDK on i386 anymore so new places have crept in.

I’ll try to find the time to submit upsteam bug reports for both the format specifiers and implicit conversion changes after I get the OpenJDK development tree building on Linux so I can submit patches with the correct context.