### PR TITLE
Fix build failures on OpenBSD with gcc 4.9.4/amd64:

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -113,7 +113,10 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
     JVM_BASIC_ASFLAGS="-x assembler-with-cpp -mno-omit-leaf-frame-pointer -mstack-alignment=16"
   fi
   if test "x$OPENJDK_TARGET_OS" = xbsd; then
-    JVM_BASIC_ASFLAGS="-x assembler-with-cpp -mno-omit-leaf-frame-pointer -mstack-alignment=16"
+    JVM_BASIC_ASFLAGS="-x assembler-with-cpp -mno-omit-leaf-frame-pointer"
+    if test "x$TOOLCHAIN_TYPE" = xclang; then
+      JVM_BASIC_ASFLAGS+="-mstack-alignment=16"
+    fi
   fi
 ])
 

--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -115,7 +115,7 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
   if test "x$OPENJDK_TARGET_OS" = xbsd; then
     JVM_BASIC_ASFLAGS="-x assembler-with-cpp -mno-omit-leaf-frame-pointer"
     if test "x$TOOLCHAIN_TYPE" = xclang; then
-      JVM_BASIC_ASFLAGS+="-mstack-alignment=16"
+      JVM_BASIC_ASFLAGS+=" -mstack-alignment=16"
     fi
   fi
 ])

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -50,7 +50,7 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     # seem needed any more.
     ADLC_CFLAGS_WARNINGS := -W3 -D_CRT_SECURE_NO_WARNINGS
   else ifeq ($(OPENJDK_BUILD_OS), bsd)
-    ADLC_CFLAGS := -fno-exceptions
+    ADLC_CFLAGS := -fno-exceptions -D_ALLBSD_SOURCE=1 -D_BSDONLY_SOURCE
   endif
 
   # Set the C++ standard if supported

--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -205,6 +205,10 @@ else ifeq ($(OPENJDK_TARGET_OS), bsd)
     BUILD_LIBJVM_unsafe.cpp_CXXFLAGS := -O1
   endif
 
+  ifeq ($(TOOLCHAIN_TYPE), gcc)
+    BUILD_LIBJVM_unsafe.cpp_CXXFLAGS += -Wno-maybe-uninitialized
+  endif
+
   ifeq ($(TOOLCHAIN_TYPE), clang)
     # The following files are compiled at various optimization
     # levels due to optimization issues encountered at the

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2478,14 +2478,14 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
       // Does this overlap the block we wanted? Give back the overlapped
       // parts and try again.
 
-      size_t top_overlap = requested_addr + (bytes + gap) - base[i];
-      if (top_overlap >= 0 && top_overlap < bytes) {
+      ptrdiff_t top_overlap = requested_addr + (bytes + gap) - base[i];
+      if (top_overlap >= 0 && (size_t)top_overlap < bytes) {
         unmap_memory(base[i], top_overlap);
         base[i] += top_overlap;
         size[i] = bytes - top_overlap;
       } else {
-        size_t bottom_overlap = base[i] + bytes - requested_addr;
-        if (bottom_overlap >= 0 && bottom_overlap < bytes) {
+        ptrdiff_t bottom_overlap = base[i] + bytes - requested_addr;
+        if (bottom_overlap >= 0 && (size_t)bottom_overlap < bytes) {
           unmap_memory(requested_addr, bottom_overlap);
           size[i] = bytes - bottom_overlap;
         } else {
@@ -3243,7 +3243,7 @@ void os::Bsd::install_signal_handlers() {
 
 static const char* get_signal_handler_name(address handler,
                                            char* buf, int buflen) {
-  int offset;
+  int offset = 0;
   bool found = os::dll_address_to_library_name(handler, buf, buflen, &offset);
   if (found) {
     // skip directory names

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -121,6 +121,10 @@
 #include <lwp.h>
 #endif
 
+#ifdef __OpenBSD__
+# include <pthread_np.h>
+#endif
+
 #ifdef __APPLE__
   #include <mach/mach.h> // semaphore_* API
   #include <mach-o/dyld.h>

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -56,7 +56,6 @@
 // put OS-includes here
 # include <sys/types.h>
 # include <sys/mman.h>
-# include <pthread.h>
 # include <signal.h>
 # include <errno.h>
 # include <dlfcn.h>
@@ -64,7 +63,6 @@
 # include <stdio.h>
 # include <unistd.h>
 # include <sys/resource.h>
-# include <pthread.h>
 # include <sys/stat.h>
 # include <sys/time.h>
 # include <sys/utsname.h>
@@ -74,10 +72,6 @@
 # include <poll.h>
 #ifndef __OpenBSD__
 # include <ucontext.h>
-#endif
-
-#if !defined(__APPLE__) && !defined(__NetBSD__)
-# include <pthread_np.h>
 #endif
 
 // needed by current_stack_region() workaround for Mavericks

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1491,7 +1491,6 @@ static const char* errno_to_string (int e, bool short_text) {
     X(ENOENT, "No such file or directory") \
     X(ENOEXEC, "Executable file format error") \
     X(ENOLCK, "No locks available") \
-    X(ENOLINK, "Reserved") \
     X(ENOMEM, "Not enough space") \
     X(ENOMSG, "No message of the desired type") \
     X(ENOPROTOOPT, "Protocol not available") \
@@ -1542,6 +1541,9 @@ static const char* errno_to_string (int e, bool short_text) {
     #endif
     #ifdef ENODATA
     DEFINE_ENTRY(ENODATA, "No message is available on the STREAM head read queue")
+    #endif
+    #ifdef ENOLINK
+    DEFINE_ENTRY(ENOLINK, "Reserved")
     #endif
     #ifdef ENOSR
     DEFINE_ENTRY(ENOSR, "No STREAM resources")


### PR DESCRIPTION
* Adjust headers for move of methods from os_bsd_x86.cpp to os_bsd.cpp
* ENOLINK is not defined on OpenBSD with gcc
* Use ptrdiff_t in os::pd_attempt_reserve_memory_at() for -Wtype-limits. [1]
* Initialize offset to 0 in get_signal_handler_name() for -Wuninitialized. [2]
* -mstack-alignment=16 is clang only. gcc defaults to an equivalent value:
  -mpreferred-stack-boundary=4 (2^4) so no need to specify it for gcc.
* Add missing BSD defines for Adlc resulting in missing includes that require
   _ALLBSD_SOURCE
* Disable maybe-uninitialized for unsafe.cpp due to incorrect warning from
   gcc 4.9 

[1] https://github.com/battleblow/openjdk-jdk11u/commit/71e05f61f16d4d0dd12b9f7b28c0926ef3f94fd5
[2] https://github.com/battleblow/openjdk-jdk11u/commit/09841abe88fcd750854ff3c9f974570e9477dce8