### PR TITLE
Completely disable sctp on OpenBSD & NetBSD:

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -384,10 +384,18 @@ endif
 
 ifeq ($(OPENJDK_TARGET_OS_ENV), bsd.openbsd)
   jdk.sctp_EXCLUDE_FILES += $(SCTP_IMPL_CLASSES)
+  ## WORKAROUND need to provide Impl classes that throw UnsupportedOperationException
+  ifeq ($(MODULE), jdk.sctp)
+    SRC_SUBDIRS += macosx/classes
+  endif
 endif
 
 ifeq ($(OPENJDK_TARGET_OS_ENV), bsd.netbsd)
   jdk.sctp_EXCLUDE_FILES += $(SCTP_IMPL_CLASSES)
+  ## WORKAROUND need to provide Impl classes that throw UnsupportedOperationException
+  ifeq ($(MODULE), jdk.sctp)
+    SRC_SUBDIRS += macosx/classes
+  endif
 endif
 
 ################################################################################


### PR DESCRIPTION
Provide Impl classes that throw UnsupportedOperationException by using
the macosx sctp classes. Corrects java.lang.NoClassDefFoundError
exceptions when attempting to use sctp.