### PR TITLE
Hotspot/Large pages: FreeBSD support proposal.

### DIFF
--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -47,9 +47,6 @@
   product(bool, UseBsdPosixThreadCPUClocks, true,                               \
           "enable fast Bsd Posix clocks where available")                       \
                                                                                 \
-  product(bool, UseHugeTLBFS, false,                                            \
-          "Use MAP_HUGETLB for large pages")                                    \
-                                                                                \
   product(bool, UseSHM, false,                                                  \
           "Use SYSV shared memory for large pages")
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2328,13 +2328,52 @@ bool os::Bsd::hugetlbfs_sanity_check(bool warn, size_t page_size) {
 
 // Large page support
 
-static size_t _large_page_size = 0;
+static size_t _large_page_size =
+#if defined(__FreeBSD__)
+    AARCH64_ONLY(2 * M)
+    AMD64_ONLY(2 * M)
+    ARM32_ONLY(2 * M)
+    PPC_ONLY(4 * M)
+    SPARC_ONLY(4 * M);
+#else
+    0;
+#endif
 
 void os::large_page_init() {
+#if defined(__FreeBSD__)
+	unsigned int super_pg = 0;
+	size_t length = sizeof(super_pg);
+	// Boot time only knob
+	if (sysctlbyname("vm.pmap.pg_ps_enabled", &super_pg, &length, NULL, 0) == -1 ||
+            super_pg < 1) {
+		_large_page_size = 0;
+	}
+#endif
 }
 
 
 char* os::reserve_memory_special(size_t bytes, size_t alignment, char* req_addr, bool exec) {
+#if defined(__FreeBSD__)
+  assert(UseLargePages && os::large_page_size() > 0, "only for mmap large pages");
+  assert(is_aligned(bytes, os::large_page_size()), "Unaligned size");
+  assert(is_aligned(req_addr, os::large_page_size()), "Unaligned base address");
+  char *addr;
+  int err;
+
+  int pflags = PROT_READ|PROT_WRITE;
+  if (exec) {
+    pflags |= PROT_EXEC;
+  }
+  int mflags = MAP_PRIVATE|MAP_ANONYMOUS|
+	       MAP_ALIGNED_SUPER|MAP_FIXED;
+
+  bool warn_on_failure = UseLargePages &&
+                         (!FLAG_IS_DEFAULT(UseLargePages) ||
+                          !FLAG_IS_DEFAULT(LargePageSizeInBytes));
+
+  addr = (char *)mmap(req_addr, bytes, pflags, mflags, -1, 0);
+  err = errno;
+#else
   fatal("This code is not used or maintained.");
 
   // "exec" is passed in but not used.  Creating the shared image for
@@ -2381,6 +2420,7 @@ char* os::reserve_memory_special(size_t bytes, size_t alignment, char* req_addr,
   // terminates. If shmat() is not successful this will remove the shared
   // segment immediately.
   shmctl(shmid, IPC_RMID, NULL);
+#endif
 
   if ((intptr_t)addr == -1) {
     if (warn_on_failure) {
@@ -2396,6 +2436,9 @@ char* os::reserve_memory_special(size_t bytes, size_t alignment, char* req_addr,
 }
 
 bool os::release_memory_special(char* base, size_t bytes) {
+#if defined(__FreeBSD__)
+  return anon_munmap(base, bytes);
+#else
   if (MemTracker::tracking_level() > NMT_minimal) {
     Tracker tkr(Tracker::release);
     // detaching the SHM segment will also delete it, see reserve_memory_special()
@@ -2409,6 +2452,7 @@ bool os::release_memory_special(char* base, size_t bytes) {
   } else {
     return shmdt(base) == 0;
   }
+#endif
 }
 
 size_t os::large_page_size() {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2341,12 +2341,13 @@ static size_t _large_page_size =
 
 void os::large_page_init() {
 #if defined(__FreeBSD__)
+	if (!UseLargePages) return;
 	unsigned int super_pg = 0;
 	size_t length = sizeof(super_pg);
 	// Boot time only knob
 	if (sysctlbyname("vm.pmap.pg_ps_enabled", &super_pg, &length, NULL, 0) == -1 ||
             super_pg < 1) {
-		_large_page_size = 0;
+		UseLargePages = false;
 	}
 #endif
 }
@@ -2459,15 +2460,12 @@ size_t os::large_page_size() {
   return _large_page_size;
 }
 
-// HugeTLBFS allows application to commit large page memory on demand;
-// with SysV SHM the entire memory region must be allocated as shared
-// memory.
 bool os::can_commit_large_page_memory() {
-  return UseHugeTLBFS;
+  return false;
 }
 
 bool os::can_execute_large_page_memory() {
-  return UseHugeTLBFS;
+  return true;
 }
 
 char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2333,6 +2333,7 @@ static size_t _large_page_size =
     AARCH64_ONLY(2 * M)
     AMD64_ONLY(2 * M)
     ARM32_ONLY(2 * M)
+    IA32_ONLY(2 * M)
     PPC_ONLY(4 * M)
     SPARC_ONLY(4 * M);
 #else

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1883,7 +1883,7 @@ jint Arguments::set_aggressive_heap_flags() {
     }
   }
 
-#if !defined(_ALLBSD_SOURCE) && !defined(AIX)  // UseLargePages is not yet supported on BSD and AIX.
+#if !defined(_ALLBSD_SOURCE) && !defined(__FreeBSD__) && !defined(AIX)  // UseLargePages is not yet supported on most of BSDs and AIX.
   FLAG_SET_DEFAULT(UseLargePages, true);
 #endif
 
@@ -3849,7 +3849,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
             " names that are reserved for internal use.");
   }
 
-#if defined(_ALLBSD_SOURCE) || defined(AIX)  // UseLargePages is not yet supported on BSD and AIX.
+#if (defined(_ALLBSD_SOURCE) && !defined(__FreeBSD__))|| defined(AIX)  // UseLargePages is not yet supported on most of BSDs and AIX.
   UNSUPPORTED_OPTION(UseLargePages);
 #endif
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1883,7 +1883,7 @@ jint Arguments::set_aggressive_heap_flags() {
     }
   }
 
-#if !defined(_ALLBSD_SOURCE) && !defined(__FreeBSD__) && !defined(AIX)  // UseLargePages is not yet supported on most of BSDs and AIX.
+#if !(defined(_ALLBSD_SOURCE) && !defined(__FreeBSD__)) && !defined(AIX)  // UseLargePages is not yet supported on most of BSDs and AIX.
   FLAG_SET_DEFAULT(UseLargePages, true);
 #endif
 
@@ -3849,7 +3849,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
             " names that are reserved for internal use.");
   }
 
-#if (defined(_ALLBSD_SOURCE) && !defined(__FreeBSD__))|| defined(AIX)  // UseLargePages is not yet supported on most of BSDs and AIX.
+#if (defined(_ALLBSD_SOURCE) && !defined(__FreeBSD__)) || defined(AIX)  // UseLargePages is not yet supported on most of BSDs and AIX.
   UNSUPPORTED_OPTION(UseLargePages);
 #endif
 


### PR DESCRIPTION
Enabling UseLargePages flag but only via FreeBSD's super page's feature,
 aligned to the arch page size.
It exists since ~2008, so it is safe here and can be enabled/disabled
at boot time only so we check it regardless.