### PR TITLE
Add BSD support to aot

### DIFF
--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/BinaryContainer.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/BinaryContainer.java
@@ -530,6 +530,9 @@ public final class BinaryContainer implements SymbolTable {
         switch (osName) {
             case "Linux":
             case "SunOS":
+            case "OpenBSD":
+            case "FreeBSD":
+            case "NetBSD":
                 JELFRelocObject elfobj = JELFRelocObject.newInstance(this, outputFileName);
                 elfobj.createELFRelocObject(relocationTable, symbolTable.values());
                 break;

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/elf/ElfTargetInfo.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/elf/ElfTargetInfo.java
@@ -63,9 +63,16 @@ final class ElfTargetInfo {
         }
 
         osName = System.getProperty("os.name").toLowerCase();
-        if (!osName.equals("linux") && !osName.equals("sunos")) {
-            System.out.println("Unsupported Operating System " + osName);
-            osName = "Unknown";
+        switch (osName) {
+            case "linux":
+            case "sunos":
+            case "openbsd":
+            case "freebsd":
+            case "netbsd":
+                break;
+            default:
+                System.out.println("Unsupported Operating System " + osName);
+                osName = "Unknown";
         }
     }
 

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc/src/jdk/tools/jaotc/Linker.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc/src/jdk/tools/jaotc/Linker.java
@@ -66,6 +66,9 @@ final class Linker {
 
         switch (options.osName) {
             case "Linux":
+            case "OpenBSD":
+            case "FreeBSD":
+            case "NetBSD":
                 if (name.endsWith(".so")) {
                     objectFileName = name.substring(0, name.length() - ".so".length());
                 }

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfigBase.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfigBase.java
@@ -73,6 +73,9 @@ public abstract class GraalHotSpotVMConfigBase extends HotSpotVMConfigAccess {
                 osName = "solaris";
                 break;
             case "Mac OS X":
+            case "OpenBSD":
+            case "FreeBSD":
+            case "NetBSD":
                 osName = "bsd";
                 break;
             default:


### PR DESCRIPTION
Notes:
All `hotspot/jtreg/compiler/aot` tests pass now on OpenBSD/amd64.
