### PR TITLE
FreeBSD/socket: user cookie socket option support.

### DIFF
--- a/src/jdk.net/bsd/classes/jdk/net/BsdSocketOptions.java
+++ b/src/jdk.net/bsd/classes/jdk/net/BsdSocketOptions.java
@@ -76,6 +76,7 @@ class BsdSocketOptions extends PlatformSocketOptions {
     private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
     private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
     private static native boolean keepAliveOptionsSupported0();
+    private static native void setUserCookie(int fd, int cookie) throws SocketException;
     static {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             System.loadLibrary("extnet");

--- a/src/jdk.net/bsd/classes/jdk/net/BsdSocketOptions.java
+++ b/src/jdk.net/bsd/classes/jdk/net/BsdSocketOptions.java
@@ -76,7 +76,7 @@ class BsdSocketOptions extends PlatformSocketOptions {
     private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
     private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
     private static native boolean keepAliveOptionsSupported0();
-    private static native void setUserCookie(int fd, int cookie) throws SocketException;
+    public static native void setUserCookie(int fd, int cookie) throws SocketException;
     static {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             System.loadLibrary("extnet");

--- a/src/jdk.net/bsd/native/libextnet/BsdSocketOptions.c
+++ b/src/jdk.net/bsd/native/libextnet/BsdSocketOptions.c
@@ -182,3 +182,17 @@ JNIEXPORT jint JNICALL Java_jdk_net_BsdSocketOptions_getTcpKeepAliveIntvl0
     return optval;
 #endif
 }
+
+JNIEXPORT void JNICALL Java_jdk_net_BsdSocketOptions_setUserCookie
+(JNIEnv *env, jobject unused, jint fd, jint cookie) {
+#ifndef __FreeBSD__
+    JNU_ThrowByName(env, "java/lang/UnsupportedOperationException",
+                    "unsupported socket option");
+#else
+   jint rv;
+   const uint32_t optval = (const uint32_t)cookie;
+   socklen_t sz = sizeof (optval);
+   rv = setsockopt(fd, IPPROTO_TCP, SO_USER_COOKIE, &optval, sz);
+   handleError(env, rv, "set option SO_USER_COOKIE failed");
+#endif
+}


### PR DESCRIPTION
giving here an identifier to the socket for DTrace's context,
ipfw filter and so on.