### PR TITLE
JFR CPUPerformance BSD implementation:

### DIFF
--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -132,8 +132,11 @@ size_t length = sizeof(cpu_load_info);
     memcpy(cpu_load_info, &allcpus[which_logical_cpu * CPUSTATES], sizeof(long) * CPUSTATES);
     FREE_C_HEAP_ARRAY(long, allcpus);
 #else
-    /* TODO: NetBSD */
-    return FUNCTIONALITY_NOT_IMPLEMENTED;
+    char mib[24];
+    snprintf(mib, sizeof(mib), "kern.cp_time.%d", which_logical_cpu);
+    if (sysctlbyname(mib, &cpu_load_info, &length, NULL, 0) == -1) {
+      return OS_ERR;
+    }
 #endif
   }
 

--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -121,14 +121,16 @@ size_t length = sizeof(cpu_load_info);
       return OS_ERR;
     }
 #elif defined(__FreeBSD__)
-    size_t alllength = length * nProcs * sizeof(long);
-    long *allcpus = NEW_C_HEAP_ARRAY(long, alllength, mtInternal);
+    size_t alllength = length * nProcs;
+    long *allcpus = NEW_C_HEAP_ARRAY(long, CPUSTATES * nProcs, mtInternal);
 
     if (sysctlbyname("kern.cp_times", allcpus, &alllength, NULL, 0) == -1) {
+      FREE_C_HEAP_ARRAY(long, allcpus);
       return OS_ERR;
     }
 
     memcpy(cpu_load_info, &allcpus[which_logical_cpu * CPUSTATES], sizeof(long) * CPUSTATES);
+    FREE_C_HEAP_ARRAY(long, allcpus);
 #else
     /* TODO: NetBSD */
     return FUNCTIONALITY_NOT_IMPLEMENTED;

--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -120,8 +120,17 @@ size_t length = sizeof(cpu_load_info);
     if (sysctl(mib, miblen, &cpu_load_info, &length, NULL, 0) == -1) {
       return OS_ERR;
     }
+#elif defined(__FreeBSD__)
+    size_t alllength = length * nProcs * sizeof(long);
+    long *allcpus = NEW_C_HEAP_ARRAY(long, alllength, mtInternal);
+
+    if (sysctlbyname("kern.cp_times", allcpus, &alllength, NULL, 0) == -1) {
+      return OS_ERR;
+    }
+
+    memcpy(cpu_load_info, &allcpus[which_logical_cpu * CPUSTATES], sizeof(long) * CPUSTATES);
 #else
-    /* TODO: FreeBSD and NetBSD */
+    /* TODO: NetBSD */
     return FUNCTIONALITY_NOT_IMPLEMENTED;
 #endif
   }


### PR DESCRIPTION
* Implementation for *BSD that is consistent with Linux's implementation
  per discussion in #37
* cpu_load() for individual processors left to do for FreeBSD and NetBSD

Notes:
Tested on OpenBSD/amd64 only with jtreg `jdk/jfr/event/os` and standalone.