### PR TITLE
Adjust BSD os::thread_cpu_time() implementation:

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -3973,33 +3973,15 @@ bool os::pd_unmap_memory(char* addr, size_t bytes) {
 // the fast estimate available on the platform.
 
 jlong os::current_thread_cpu_time() {
-#ifdef __APPLE__
   return os::thread_cpu_time(Thread::current(), true /* user + sys */);
-#else
-  if (Bsd::_getcpuclockid != NULL)
-    return os::thread_cpu_time(Thread::current(), true /* user + sys */);
-  return -1;
-#endif
 }
 
 jlong os::thread_cpu_time(Thread* thread) {
-#ifdef __APPLE__
   return os::thread_cpu_time(thread, true /* user + sys */);
-#else
-  if (Bsd::_getcpuclockid != NULL)
-    return os::thread_cpu_time(thread, true /* user + sys */);
-  return -1;
-#endif
 }
 
 jlong os::current_thread_cpu_time(bool user_sys_cpu_time) {
-#ifdef __APPLE__
   return os::thread_cpu_time(Thread::current(), user_sys_cpu_time);
-#else
-  if (Bsd::_getcpuclockid != NULL)
-    return os::thread_cpu_time(Thread::current(), user_sys_cpu_time);
-  return -1;
-#endif
 }
 
 jlong os::thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
@@ -4024,6 +4006,45 @@ jlong os::thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
     return ((jlong)tinfo.user_time.seconds * 1000000000) + ((jlong)tinfo.user_time.microseconds * (jlong)1000);
   }
 #else
+#if defined(__OpenBSD__)
+  size_t length = 0;
+  pid_t pid = getpid();
+  struct kinfo_proc *ki;
+
+  int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID|KERN_PROC_SHOW_THREADS, pid, sizeof(struct kinfo_proc), 0 };
+  const u_int miblen = sizeof(mib) / sizeof(mib[0]);
+
+  if (sysctl(mib, miblen, NULL, &length, NULL, 0) < 0) {
+    return -1;
+  }
+
+  size_t num_threads = length / sizeof(*ki);
+  ki = NEW_C_HEAP_ARRAY(struct kinfo_proc, num_threads, mtInternal);
+
+  mib[5] = num_threads;
+
+  if (sysctl(mib, miblen, ki, &length, NULL, 0) < 0) {
+    FREE_C_HEAP_ARRAY(struct kinfo_proc, ki);
+    return -1;
+  }
+
+  num_threads = length / sizeof(*ki);
+
+  for (size_t i = 0; i < num_threads; i++) {
+    if (ki[i].p_tid == thread->osthread()->thread_id()) {
+      jlong nanos = (jlong)ki[i].p_uutime_sec * NANOSECS_PER_SEC;
+      nanos += (jlong)ki[i].p_uutime_usec * 1000;
+      if (user_sys_cpu_time) {
+        nanos += (jlong)ki[i].p_ustime_sec * NANOSECS_PER_SEC;
+        nanos += (jlong)ki[i].p_ustime_usec * 1000;
+      }
+      FREE_C_HEAP_ARRAY(struct kinfo_proc, ki);
+      return nanos;
+    }
+  }
+  FREE_C_HEAP_ARRAY(struct kinfo_proc, ki);
+  return -1;
+#else /* !OpenBSD */
   if (user_sys_cpu_time && Bsd::_getcpuclockid != NULL) {
     struct timespec tp;
     clockid_t clockid;
@@ -4060,6 +4081,7 @@ jlong os::thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
 #endif
   return -1;
 #endif
+#endif
 }
 
 
@@ -4078,7 +4100,7 @@ void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
 }
 
 bool os::is_thread_cpu_time_supported() {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
   return true;
 #else
   return (Bsd::_getcpuclockid != NULL);


### PR DESCRIPTION
* For BSD's that have getrusage(RUSAGE_THREAD), prefer its use over
  pthread_getcpuclockid(3) since it can support both user and system cpu
  time.
* On OpenBSD, stop using pthread_getcpuclockid(3) and provide new
  implementation that supports both user and system cpu time and doesn't
  crash the JVM when called on a thread that has exited.
* Remove unnecessary checks for Bsd::_getcpuclockid != NULL in various
  methods since the underlying implementation checks for it as well as
  os::is_thread_cpu_time_supported().

Notes:
On OpenBSD:
```
gmake run-test-only TEST="runtime/jni/terminatedThread/TestTerminatedThread.java"
```
Crashed the jvm by calling pthread_getcpuclockid on a terminated thread. It appears there isn't a safe way to check if a thread is terminated in the JVM and the pthread_getcpuclockid implementation doesn't work when the caller wants just user time anyway so I coded up a alternate solution.

Making getrusage(RUSAGE_THREAD) preferred for *BSD for the the current thread wasn't strictly necessary but I think makes sense if FreeBSD and NetBSD provide fully functional implementations similar to what I have done.