### PR TITLE
Hotspot posix: build fix

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -64,6 +64,10 @@
   #define MAP_NORESERVE 0
 #endif
 
+#ifndef PTHREAD_STACK_MIN
+  #define PTHREAD_STACK_MIN 1UL << 14 // 16KB
+#endif
+
 #define check_with_errno(check_type, cond, msg)                             \
   do {                                                                      \
     int err = errno;                                                        \


### PR DESCRIPTION
NetBSD does not define this constant, here to 16kb.