### PR TITLE
Sync os_bsd_x86.cpp _get_previous_fp() and os::current_stack_pointer()

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -273,13 +273,9 @@
 
 address os::current_stack_pointer() {
 #if defined(__clang__) || defined(__llvm__)
-  register void *esp;
-  __asm__("mov %%" SPELL_REG_SP ", %0":"=r"(esp));
+  intptr_t* esp;
+  __asm__ __volatile__ ("mov %%" SPELL_REG_SP ", %0":"=r"(esp):);
   return (address) esp;
-#elif defined(SPARC_WORKS)
-  register void *esp;
-  __asm__("mov %%" SPELL_REG_SP ", %0":"=r"(esp));
-  return (address) ((char*)esp + sizeof(long)*2);
 #else
   register void *esp __asm__ (SPELL_REG_SP);
   return (address) esp;
@@ -404,9 +400,9 @@ frame os::get_sender_for_C_frame(frame* fr) {
 }
 
 intptr_t* _get_previous_fp() {
-#if defined(SPARC_WORKS) || defined(__clang__) || defined(__llvm__)
-  register intptr_t **ebp;
-  __asm__("mov %%" SPELL_REG_FP ", %0":"=r"(ebp));
+#if defined(__clang__) || defined(__llvm__)
+  intptr_t **ebp;
+  __asm__ __volatile__ ("mov %%" SPELL_REG_FP ", %0":"=r"(ebp):);
 #else
   register intptr_t **ebp __asm__ (SPELL_REG_FP);
 #endif


### PR DESCRIPTION
with Linux version for clang. (drop `register`, add `__volatile__`)