### PR TITLE
Throw IOException when DirectIO is not supported in setDirect0()

### DIFF
--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -361,6 +361,7 @@ Java_sun_nio_ch_FileDispatcherImpl_setDirect0(JNIEnv *env, jclass clazz,
         result = (int)file_stat.f_frsize;
     }
 #else
+    JNU_ThrowIOException(env, "DirectIO unsupported");
     result = -1;
 #endif
     return result;


### PR DESCRIPTION
so that setDirectIO() will throw UnsupportedOperationException
out to the caller.