### PR TITLE
Various Clang Build Corrections

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -519,6 +519,10 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     # works for all platforms.
     TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -mno-omit-leaf-frame-pointer -mstack-alignment=16"
 
+    if test "x$OPENJDK_TARGET_CPU" = xx86; then
+      TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -mstackrealign"
+    fi
+
     if test "x$OPENJDK_TARGET_OS" = xlinux; then
       TOOLCHAIN_CFLAGS_JDK="-pipe"
       TOOLCHAIN_CFLAGS_JDK_CONLY="-fno-strict-aliasing" # technically NOT for CXX

--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -210,6 +210,14 @@ else ifeq ($(OPENJDK_TARGET_OS), bsd)
   endif
 
   ifeq ($(TOOLCHAIN_TYPE), clang)
+    ifeq ($(OPENJDK_TARGET_CPU), x86)
+      ifneq ($(DEBUG_LEVEL), slowdebug)
+        # hotspot/jtreg/compiler/c2/Test8062950.java test fails on x86
+        # with clang when parse2.cpp is optimized above -O1
+        BUILD_LIBJVM_parse2.cpp_CXXFLAGS := -O1
+      endif
+    endif
+
     # The following files are compiled at various optimization
     # levels due to optimization issues encountered at the
     # default level. The Clang compiler issues a compile
@@ -224,7 +232,8 @@ else ifeq ($(OPENJDK_TARGET_OS), bsd)
         sharedRuntimeTrig.cpp \
         sharedRuntimeTrans.cpp \
         loopTransform.cpp \
-        unsafe.cpp
+        unsafe.cpp \
+        parse2.cpp \
         #
   endif
 

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -271,16 +271,18 @@
 # endif
 #endif
 
-address os::current_stack_pointer() {
 #if defined(__clang__) || defined(__llvm__)
+address os::current_stack_pointer() __attribute__ ((optnone)) {
   intptr_t* esp;
   __asm__ __volatile__ ("mov %%" SPELL_REG_SP ", %0":"=r"(esp):);
   return (address) esp;
+}
 #else
+address os::current_stack_pointer() {
   register void *esp __asm__ (SPELL_REG_SP);
   return (address) esp;
-#endif
 }
+#endif
 
 char* os::non_memory_address_word() {
   // Must never look like an address returned by reserve_memory,
@@ -975,6 +977,7 @@ void os::setup_fpu() {
 
 #ifndef PRODUCT
 void os::verify_stack_alignment() {
+  assert(((intptr_t)os::current_stack_pointer() & (StackAlignmentInBytes-1)) == 0, "incorrect stack alignment");
 }
 #endif
 


### PR DESCRIPTION
* On x86 (32bit) with clang add -mstackrealign to JVM CFLAGS
* Enable os::verify_stack_alignment() on BSD
* Reduce optimization level for parse2.cpp on x86 with clang