### PR TITLE
Fix building gtest on FreeBSD/NetBSD:

### DIFF
--- a/test/fmw/gtest/include/gtest/internal/gtest-port.h
+++ b/test/fmw/gtest/include/gtest/internal/gtest-port.h
@@ -99,7 +99,7 @@
 //     GTEST_OS_IOS    - iOS
 //       GTEST_OS_IOS_SIMULATOR - iOS simulator
 //   GTEST_OS_NACL     - Google Native Client (NaCl)
-//   GTEST_OS_OPENBSD  - OpenBSD
+//   GTEST_OS_BSD      - OpenBSD, FreeBSD, NetBSD
 //   GTEST_OS_QNX      - QNX
 //   GTEST_OS_SOLARIS  - Sun Solaris
 //   GTEST_OS_SYMBIAN  - Symbian
@@ -263,8 +263,8 @@
 # define GTEST_OS_HPUX 1
 #elif defined __native_client__
 # define GTEST_OS_NACL 1
-#elif defined __OpenBSD__
-# define GTEST_OS_OPENBSD 1
+#elif defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+# define GTEST_OS_BSD 1
 #elif defined __QNX__
 # define GTEST_OS_QNX 1
 #endif  // __CYGWIN__
@@ -646,7 +646,7 @@ using ::std::tuple_size;
      (GTEST_OS_MAC && !GTEST_OS_IOS) || GTEST_OS_IOS_SIMULATOR || \
      (GTEST_OS_WINDOWS_DESKTOP && _MSC_VER >= 1400) || \
      GTEST_OS_WINDOWS_MINGW || GTEST_OS_AIX || GTEST_OS_HPUX || \
-     GTEST_OS_OPENBSD || GTEST_OS_QNX)
+     GTEST_OS_BSD || GTEST_OS_QNX)
 # define GTEST_HAS_DEATH_TEST 1
 # include <vector>  // NOLINT
 #endif


### PR DESCRIPTION
Tested on OpenBSD/amd64 and FreeBSD/aarch64 with #50