### PR TITLE
Add debugger support for aarch64

### DIFF
--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.c
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.c
@@ -38,6 +38,10 @@
 #include "sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext.h"
 #endif
 
+#ifdef aarch64
+#include "sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext.h"
+#endif
+ 
 #ifdef ppc64
 #include "sun_jvm_hotspot_debugger_ppc64_PPC64ThreadContext.h"
 #endif
@@ -372,6 +376,19 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
 //  regs[REG_INDEX(GS)] = gregs.gs;
 
 #endif /* amd64 */
+
+#if defined(aarch64)
+
+#define REG_INDEX(reg) sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext_##reg
+
+  {
+    int i;
+    for (i = 0; i < 31; i++)
+      regs[i] = gregs.regs[i];
+    regs[REG_INDEX(SP)] = gregs.gp_sp;
+    regs[REG_INDEX(PC)] = gregs.gp_elr;
+  }
+#endif /* aarch64 */
 
 #if defined(sparc) || defined(sparcv9)
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -627,10 +627,12 @@ public class HotSpotAgent {
             machDesc = new MachineDescriptionIntelX86();
         } else if (cpu.equals("amd64") || cpu.equals("x86_64")) {
             machDesc = new MachineDescriptionAMD64();
+        } else if (cpu.equals("aarch64")) {
+            machDesc = new MachineDescriptionAArch64();
         } else if (cpu.equals("ppc64")) {
             machDesc = new MachineDescriptionPPC64();
         } else {
-            throw new DebuggerException("BSD only supported on x86/x86_64/ppc64. Current arch: " + cpu);
+            throw new DebuggerException("BSD only supported on x86/x86_64/aarch64/ppc64. Current arch: " + cpu);
         }
 
         BsdDebuggerLocal dbg = new BsdDebuggerLocal(machDesc, !isServer);


### PR DESCRIPTION
These changes add debugger support for aarch64 and should fix the error messages in issue #55.  I don't have access to a FBSD/aarch64 system and have not tested these changes.