### PR TITLE
Stack overflow and SO_LINGER changes

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -510,6 +510,9 @@ JVM_handle_bsd_signal(int sig,
     // Handle ALL stack overflow variations here
     if (sig == SIGSEGV || sig == SIGBUS) {
       address addr = (address) info->si_addr;
+#ifdef __FreeBSD__
+      addr = align_down(addr, os::vm_page_size());
+#endif
 
       // check if fault address is within thread stack
       if (thread->on_local_stack(addr)) {

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -1020,8 +1020,8 @@ class Socket implements java.io.Closeable {
             if (linger < 0) {
                 throw new IllegalArgumentException("invalid value for SO_LINGER");
             }
-            if (linger > 65535)
-                linger = 65535;
+            if (linger > 32767)
+                linger = 32767;
             getImpl().setOption(SocketOptions.SO_LINGER, linger);
         }
     }

--- a/test/jdk/java/net/Socket/SetSoLinger.java
+++ b/test/jdk/java/net/Socket/SetSoLinger.java
@@ -48,7 +48,7 @@ public class SetSoLinger {
         s.close();
         ss.close();
 
-        if(value != 65535)
+        if(value != 32767)
             throw new RuntimeException("Failed. Value not properly reduced.");
     }
 }


### PR DESCRIPTION
Looking to get some review of a couple of fixes on the jck-testing branch before merging them into bsd-port.

Stack overflow workaround.  This is a possible way to handle the problem on FreeBSD where it doesn't properly detect a stack overflow and instead crashes.  The address of the fault is consistently within the page next to the reserved zone and aligning it (down) to a page puts it on the boundary, which is then detected as in the zone by the stack overflow checks.  Analysing the stack size and mprotect calls has not found anything that explains why the fault address is outside the reserved zone.  In the absence of that, this workaround is the most reasonable thing I've found so far.

SO_LINGER change.  On *BSD it looks like the linger value is stored in a signed short, making 32767 the effective maximum value.  I chose to apply this without making it conditional on OS since this is still a large amount of time (9+ hours) and I wanted to keep the code simple rather than introducing OS checks.  Introducing such an OS check is the alternative.