### PR TITLE
Restore static linking of libjli for BSD

### DIFF
--- a/make/launcher/LauncherCommon.gmk
+++ b/make/launcher/LauncherCommon.gmk
@@ -30,7 +30,7 @@ ORIGIN_ARG := $(call SET_EXECUTABLE_ORIGIN,/../lib/jli)
 # Applications expect to be able to link against libjawt without invoking
 # System.loadLibrary("jawt") first. This was the behaviour described in the
 # devloper documentation of JAWT and what worked with OpenJDK6.
-ifneq ($(findstring $(OPENJDK_TARGET_OS), linux solaris bsd), )
+ifneq ($(findstring $(OPENJDK_TARGET_OS), linux solaris), )
   ORIGIN_ARG += $(call SET_EXECUTABLE_ORIGIN,/../lib)
 endif
 
@@ -144,7 +144,7 @@ define SetupBuildLauncherBody
         -framework ApplicationServices
   endif
 
-  ifeq ($(OPENJDK_TARGET_OS), aix)
+  ifneq ($(findstring $(OPENJDK_TARGET_OS), aix bsd), )
     $1_LDFLAGS += -L$(SUPPORT_OUTPUTDIR)/native/java.base
     $1_LIBS += -ljli_static
   endif
@@ -178,12 +178,10 @@ define SetupBuildLauncherBody
           -L$(call FindLibDirForModule, java.base)/jli, \
       LDFLAGS_solaris := $$($1_LDFLAGS_solaris) \
           -L$(call FindLibDirForModule, java.base)/jli, \
-      LDFLAGS_bsd := \
-          -L$(call FindLibDirForModule, java.base)/jli, \
       LIBS := $(JDKEXE_LIBS) $$($1_LIBS), \
       LIBS_unix := $$($1_LIBS_unix), \
       LIBS_linux := -lpthread -ljli $(LIBDL), \
-      LIBS_bsd := -pthread -ljli $(LIBDL), \
+      LIBS_bsd := -pthread, \
       LIBS_macosx := -ljli, \
       LIBS_solaris := -ljli -lthread $(LIBDL), \
       LIBS_windows := $$($1_WINDOWS_JLI_LIB) \
@@ -200,7 +198,7 @@ define SetupBuildLauncherBody
   $1 += $$(BUILD_LAUNCHER_$1)
   TARGETS += $$($1)
 
-  ifeq ($(OPENJDK_TARGET_OS), aix)
+  ifneq ($(findstring $(OPENJDK_TARGET_OS), aix bsd), )
     $$(BUILD_LAUNCHER_$1): $(SUPPORT_OUTPUTDIR)/native/java.base/libjli_static.a
   endif
 

--- a/make/lib/CoreLibraries.gmk
+++ b/make/lib/CoreLibraries.gmk
@@ -260,7 +260,7 @@ TARGETS += $(BUILD_LIBJLI)
 
 LIBJLI_SRC_DIRS := $(call FindSrcDirsForComponent, java.base, libjli)
 
-ifeq ($(OPENJDK_TARGET_OS), aix)
+ifneq ($(findstring $(OPENJDK_TARGET_OS), aix bsd), )
   # AIX also requires a static libjli because the compiler doesn't support '-rpath'
   $(eval $(call SetupNativeCompilation, BUILD_LIBJLI_STATIC, \
       NAME := jli_static, \

--- a/make/lib/Lib-java.instrument.gmk
+++ b/make/lib/Lib-java.instrument.gmk
@@ -57,14 +57,13 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBINSTRUMENT, \
     LDFLAGS_macosx := $(call SET_SHARED_LIBRARY_ORIGIN,/jli) \
         -L$(call FindLibDirForModule, java.base)/jli, \
     LDFLAGS_aix := -L$(SUPPORT_OUTPUTDIR)/native/java.base, \
-    LDFLAGS_bsd := $(call SET_SHARED_LIBRARY_ORIGIN,/jli) \
-        -L$(call FindLibDirForModule, java.base)/jli, \
+    LDFLAGS_bsd := -L$(SUPPORT_OUTPUTDIR)/native/java.base \
         $(ICONV_LDFLAGS), \
     LIBS := $(JDKLIB_LIBS), \
     LIBS_unix := -ljava -ljvm $(LIBZ_LIBS), \
     LIBS_linux := -ljli $(LIBDL), \
     LIBS_solaris := -ljli $(LIBDL), \
-    LIBS_bsd := $(ICONV_LIBS) -ljli $(LIBDL), \
+    LIBS_bsd := $(ICONV_LIBS) -ljli_static $(LIBDL), \
     LIBS_aix := -liconv -ljli_static $(LIBDL), \
     LIBS_macosx := -ljli -liconv -framework Cocoa -framework Security \
         -framework ApplicationServices, \
@@ -72,7 +71,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBINSTRUMENT, \
         $(WINDOWS_JLI_LIB), \
 ))
 
-ifeq ($(OPENJDK_TARGET_OS), aix)
+ifneq ($(filter $(OPENJDK_TARGET_OS), aix bsd), )
   $(BUILD_LIBINSTRUMENT): $(call FindStaticLib, java.base, jli_static)
 else ifeq ($(OPENJDK_TARGET_OS), windows)
   $(BUILD_LIBINSTRUMENT): $(call FindLib, java.base, jli)


### PR DESCRIPTION
* On OpenBSD $ORIGIN support is not fully functional so static linking
  is needed there.