### PR TITLE
#define UL(x)   UINT64_C(x)

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -113,6 +113,7 @@
 #define	CPU_PART(midr)	(((midr) >> 4) & 0xfff)
 #define	CPU_VAR(midr)	(((midr) >> 20) & 0xf)
 #define	CPU_REV(midr)	(((midr) >> 0) & 0xf)
+#define UL(x)   UINT64_C(x)
 
 struct cpu_desc {
 	u_int		cpu_impl;


### PR DESCRIPTION
(/usr/bin/grep -v -e "^Note: including file:" <  /root/dcompile/openjdk-jdk11u/build/bsd-aarch64-normal-server-fastdebug/make-support/failure-logs/hotspot_variant-server_libjvm_objs_vm_version_bsd_aarch64.o.log || true) | /usr/bin/head -n 12 
/root/dcompile/openjdk-jdk11u/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp:256:7: error: use of **undeclared identifier 'UL'**
  if (ID_AA64PFR0_AdvSIMD(id_aa64pfr0) == ID_AA64PFR0_AdvSIMD_IMPL || \
      ^


