### PR TITLE
Adjust physical memory sysctl datatypes

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -285,7 +285,18 @@ void os::Bsd::initialize_system_info() {
   int mib[2];
   size_t len;
   int cpu_val;
-  size_t mem_val;
+#if defined (HW_MEMSIZE) // Apple
+  uint64_t mem_val;
+  #define MEMMIB HW_MEMSIZE;
+#elif defined(HW_PHYSMEM64) // OpenBSD & NetBSD
+  int64_t mem_val;
+  #define MEMMIB HW_PHYSMEM64;
+#elif defined(HW_PHYSMEM) // FreeBSD
+  unsigned long mem_val;
+  #define MEMMIB HW_PHYSMEM;
+#else
+  #error No ways to get physmem
+#endif
 
   // get processors count via hw.ncpus sysctl
   mib[0] = CTL_HW;
@@ -298,21 +309,9 @@ void os::Bsd::initialize_system_info() {
     set_processor_count(1);   // fallback
   }
 
-  // get physical memory via hw.memsize sysctl (hw.memsize is used
-  // since it returns a 64 bit value)
+  // get physical memory via sysctl
   mib[0] = CTL_HW;
-
-#if defined (HW_MEMSIZE) // Apple
-  mib[1] = HW_MEMSIZE;
-#elif defined(HW_PHYSMEM64) // OpenBSD & NetBSD
-  mib[1] = HW_PHYSMEM64;
-#elif defined(HW_PHYSMEM) // Most of BSD
-  mib[1] = HW_PHYSMEM;
-#elif defined(HW_REALMEM) // Old FreeBSD
-  mib[1] = HW_REALMEM;
-#else
-  #error No ways to get physmem
-#endif
+  mib[1] = MEMMIB;
 
   len = sizeof(mem_val);
   if (sysctl(mib, 2, &mem_val, &len, NULL, 0) != -1) {

--- a/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
@@ -260,7 +260,7 @@ Java_com_sun_management_internal_OperatingSystemImpl_getCommittedVirtualMemorySi
         throw_internal_error(env, "task_info failed");
     }
     return t_info.virtual_size;
-f defined(__FreeBSD__)
+#elif defined(__FreeBSD__)
     FILE *fp;
     unsigned long end, start;
     jlong total = 0;
@@ -399,20 +399,24 @@ Java_com_sun_management_internal_OperatingSystemImpl_getTotalPhysicalMemorySize0
   (JNIEnv *env, jobject mbean)
 {
 #ifdef _ALLBSD_SOURCE
-    jlong result = 0;
     int mib[2];
     size_t rlen;
+#if defined (HW_MEMSIZE) // Apple
+    uint64_t result = 0;
+    #define MEMMIB HW_MEMSIZE;
+#elif defined(HW_PHYSMEM64) // OpenBSD & NetBSD
+    int64_t result = 0;
+    #define MEMMIB HW_PHYSMEM64;
+#elif defined(HW_PHYSMEM) // FreeBSD
+    unsigned long result = 0;
+    #define MEMMIB HW_PHYSMEM;
+#else
+    #error No ways to get physmem
+#endif
 
     mib[0] = CTL_HW;
-#if defined (HW_MEMSIZE) // Apple
-    mib[1] = HW_MEMSIZE;
-#elif defined(HW_PHYSMEM64) // OpenBSD & NetBSD
-    mib[1] = HW_PHYSMEM64;
-#elif defined(HW_PHYSMEM) // Most of BSD
-    mib[1] = HW_PHYSMEM;
-#else
-  #error No ways to get physmem
-#endif
+    mib[1] = MEMMIB;
+
     rlen = sizeof(result);
     if (sysctl(mib, 2, &result, &rlen, NULL, 0) != 0) {
         throw_internal_error(env, "sysctl failed");


### PR DESCRIPTION
* Adjust datatypes for physical memory sysctl to match what is
  expected per documentation on BSDs and Apple.
* Fix typo in #elif

Refs for datatypes:
https://github.com/apple/darwin-xnu/blob/master/bsd/kern/kern_mib.c#L403
https://github.com/apple/darwin-xnu/blob/master/bsd/sys/sysctl.h#L951
https://github.com/openbsd/src/blob/master/lib/libc/sys/sysctl.2#L293
https://github.com/NetBSD/src/blob/trunk/share/man/man7/sysctl.7#L258
https://github.com/freebsd/freebsd/blob/master/sys/kern/kern_mib.c#L183