### PR TITLE
Update ephemeral port ranges for BSD

### DIFF
--- a/src/java.base/unix/classes/sun/net/PortConfig.java
+++ b/src/java.base/unix/classes/sun/net/PortConfig.java
@@ -55,9 +55,15 @@ public final class PortConfig {
                     } else if (os.contains("OS X")) {
                         defaultLower = 49152;
                         defaultUpper = 65535;
-                    } else if (os.endsWith("BSD")) {
+                    } else if (os.startsWith("FreeBSD")) {
+                        defaultLower = 10000;
+                        defaultUpper = 65535;
+                    } else if (os.startsWith("NetBSD")) {
                         defaultLower = 49152;
                         defaultUpper = 65535;
+                    } else if (os.startsWith("OpenBSD")) {
+                        defaultLower = 1024;
+                        defaultUpper = 49151;
                     } else if (os.startsWith("AIX")) {
                         // The ephemeral port is OS version dependent on AIX:
                         // http://publib.boulder.ibm.com/infocenter/aix/v7r1/topic/com.ibm.aix.rsct315.admin/bl503_ephport.htm


### PR DESCRIPTION
* FreeBSD has switched to a dynamic ephemeral port range that uses sysctl
  to determine the range.  These are the defaults.
* The NetBSD and OpenBSD values are taken from <netinet/in.h>