### PR TITLE
Increase the minimum stack size for a VM thread

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -836,7 +836,7 @@ bool os::is_allocatable(size_t bytes) {
 size_t os::Posix::_compiler_thread_min_stack_allowed = 48 * K;
 size_t os::Posix::_java_thread_min_stack_allowed = 48 * K;
 #ifdef _LP64
-size_t os::Posix::_vm_internal_thread_min_stack_allowed = 64 * K;
+size_t os::Posix::_vm_internal_thread_min_stack_allowed = 128 * K;
 #else
 size_t os::Posix::_vm_internal_thread_min_stack_allowed = (48 DEBUG_ONLY(+ 4)) * K;
 #endif // _LP64


### PR DESCRIPTION
* Increase the minimum stack size for a VM thread on 64 bit architectures
  to 128k.  FreeBSD 12.x/amd64 will otherwise crash when running

```
  java -XX:VMThreadStackSize=64 -version
```

  with the error:

```
  [0.005s][warning][os,thread] Failed to start thread - pthread_create failed (EAGAIN) for attributes: stacksize: 64k, guardsize: 4k, detached.
  #
  # There is insufficient memory for the Java Runtime Environment to continue.
  # Cannot create worker GC thread. Out of system resources.
  # An error report file with more information is saved as:
  # <path>/hs_err_pidXXXXX.log
```

  With this change java just exits:

```
  The VMThreadStackSize specified is too small. Specify at least 128k
  Error: Could not create the Java Virtual Machine.
  Error: A fatal exception has occurred. Program will exit.
```

  This allows test/hotspot/jtreg/runtime/Thread/TooSmallStackSize.java to pass