### PR TITLE
Kernel stack guard pages

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -76,7 +76,13 @@
 #ifdef __FreeBSD__
 # include <sys/sysctl.h>
 # include <sys/procctl.h>
+#ifndef PROC_STACKGAP_STATUS
+#define PROC_STACKGAP_STATUS	18
 #endif
+#ifndef PROC_STACKGAP_DISABLE
+#define PROC_STACKGAP_DISABLE	0x0002
+#endif
+#endif /* __FreeBSD__ */
 
 // needed by current_stack_region() workaround for Mavericks
 #if defined(__APPLE__)
@@ -514,41 +520,53 @@ JVM_handle_bsd_signal(int sig,
     // Handle ALL stack overflow variations here
     if (sig == SIGSEGV || sig == SIGBUS) {
       address addr = (address) info->si_addr;
-#if defined(__FreeBSD__) && !defined(PROC_STACKGAP_CTL)
+#ifdef __FreeBSD__
       /*
-       * Try to work around the problems caused on FreeBSD where the kernel
-       * may place guard pages above JVM guard pages and prevent the Java
-       * thread stacks growing into the JVM guard pages.  The work around
-       * is to determine how many such pages there may be and round down the
-       * fault address so that tests of whether it is in the JVM guard zone
-       * succeed.
-       *
-       * Note that this is a partial workaround at best since the normally
-       * the JVM could then unprotect the reserved area to allow a critical
-       * section to complete.  This is not possible if the kernel has
-       * placed guard pages below the reserved area.
-       *
-       * This also suffers from the problem that the
-       * security.bsd.stack_guard_page sysctl is dynamic and may have
-       * changed since the stack was allocated.  This is likely to be rare
-       * in practice though.
-       *
-       * What this does do is prevent the JVM crashing on FreeBSD and
-       * instead throwing a StackOverflowError when infinite recursion
-       * is attempted, which is the expected behaviour.  Due to it's
-       * limitations though, objects may be in unexpected states when
-       * this occurs.
-       *
-       * A better way to avoid these problems is either to be on a new
-       * enough version of FreeBSD (one that has PROC_STACKGAP_CTL) or set
-       * security.bsd.stack_guard_page to zero.
+       * Determine whether the kernel stack guard pages have been disabled
        */
-      int guard_pages = 0;
-      size_t size = sizeof(guard_pages);
-      if (sysctlbyname("security.bsd.stack_guard_page",
-                       &guard_pages, &size, NULL, 0) == 0 &&
-          guard_pages > 0) {
-        addr -= guard_pages * os::vm_page_size();
+      int status = 0;
+      int ret = procctl(P_PID, getpid(), PROC_STACKGAP_STATUS, &status);
+
+      /*
+       * Check if the call to procctl(2) failed or the stack guard is not
+       * disabled.  Either way, we'll then attempt a workaround.
+       */
+      if (ret == -1 || !(status & PROC_STACKGAP_DISABLE)) {
+          /*
+           * Try to work around the problems caused on FreeBSD where the kernel
+           * may place guard pages above JVM guard pages and prevent the Java
+           * thread stacks growing into the JVM guard pages.  The work around
+           * is to determine how many such pages there may be and round down the
+           * fault address so that tests of whether it is in the JVM guard zone
+           * succeed.
+           *
+           * Note that this is a partial workaround at best since the normally
+           * the JVM could then unprotect the reserved area to allow a critical
+           * section to complete.  This is not possible if the kernel has
+           * placed guard pages below the reserved area.
+           *
+           * This also suffers from the problem that the
+           * security.bsd.stack_guard_page sysctl is dynamic and may have
+           * changed since the stack was allocated.  This is likely to be rare
+           * in practice though.
+           *
+           * What this does do is prevent the JVM crashing on FreeBSD and
+           * instead throwing a StackOverflowError when infinite recursion
+           * is attempted, which is the expected behaviour.  Due to it's
+           * limitations though, objects may be in unexpected states when
+           * this occurs.
+           *
+           * A better way to avoid these problems is either to be on a new
+           * enough version of FreeBSD (one that has PROC_STACKGAP_CTL) or set
+           * security.bsd.stack_guard_page to zero.
+           */
+          int guard_pages = 0;
+          size_t size = sizeof(guard_pages);
+          if (sysctlbyname("security.bsd.stack_guard_page",
+                           &guard_pages, &size, NULL, 0) == 0 &&
+              guard_pages > 0) {
+            addr -= guard_pages * os::vm_page_size();
+          }
       }
 #endif
 

--- a/src/java.base/unix/native/libjli/java_md_solinux.c
+++ b/src/java.base/unix/native/libjli/java_md_solinux.c
@@ -38,7 +38,13 @@
 #ifdef __FreeBSD__
 #include <sys/sysctl.h>
 #include <sys/procctl.h>
+#ifndef PROC_STACKGAP_DISABLE
+#define PROC_STACKGAP_DISABLE	0x0002
 #endif
+#ifndef PROC_STACKGAP_CTL
+#define PROC_STACKGAP_CTL	17
+#endif
+#endif /* __FreeBSD__ */
 #include "manifest_info.h"
 
 
@@ -817,8 +823,15 @@ JVMInit(InvocationFunctions* ifn, jlong threadStackSize,
         int argc, char **argv,
         int mode, char *what, int ret)
 {
-#if defined(__FreeBSD__) && defined(PROC_STACKGAP_CTL)
-    /* Must disable the kernel stack guard pages before threads are created */
+#ifdef __FreeBSD__
+    /*
+     * Kernel stack guard pages interfere with the JVM's guard pages on the
+     * thread stacks and prevent correct stack overflow detection and the
+     * use of reserved pages to allow critical sections to complete.
+     *
+     * Attempt to disable the kernel stack guard pages here before any threads
+     * are created.
+     */
     int arg = PROC_STACKGAP_DISABLE;
     procctl(P_PID, getpid(), PROC_STACKGAP_CTL, &arg);
 #endif

--- a/src/java.base/unix/native/libjli/java_md_solinux.c
+++ b/src/java.base/unix/native/libjli/java_md_solinux.c
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 #ifdef __FreeBSD__
 #include <sys/sysctl.h>
+#include <sys/procctl.h>
 #endif
 #include "manifest_info.h"
 
@@ -816,6 +817,11 @@ JVMInit(InvocationFunctions* ifn, jlong threadStackSize,
         int argc, char **argv,
         int mode, char *what, int ret)
 {
+#if defined(__FreeBSD__) && defined(PROC_STACKGAP_CTL)
+    /* Must disable the kernel stack guard pages before threads are created */
+    int arg = PROC_STACKGAP_DISABLE | PROC_STACKGAP_ENABLE_EXEC;
+    procctl(P_PID, getpid(), PROC_STACKGAP_CTL, &arg);
+#endif
     ShowSplashScreen();
     return ContinueInNewThread(ifn, threadStackSize, argc, argv, mode, what, ret);
 }

--- a/src/java.base/unix/native/libjli/java_md_solinux.c
+++ b/src/java.base/unix/native/libjli/java_md_solinux.c
@@ -819,7 +819,7 @@ JVMInit(InvocationFunctions* ifn, jlong threadStackSize,
 {
 #if defined(__FreeBSD__) && defined(PROC_STACKGAP_CTL)
     /* Must disable the kernel stack guard pages before threads are created */
-    int arg = PROC_STACKGAP_DISABLE | PROC_STACKGAP_ENABLE_EXEC;
+    int arg = PROC_STACKGAP_DISABLE;
     procctl(P_PID, getpid(), PROC_STACKGAP_CTL, &arg);
 #endif
     ShowSplashScreen();


### PR DESCRIPTION
Two changes

1. Disable the kernel stack guard pages on recent versions of FreeBSD.  Currently this is only FreeBSD-CURRENT as of 09/04
2. Workaround the kernel stack guard pages on other versions of FreeBSD.  This attempts to do something reasonable knowing that it can't resolve all of the issues.