### PR TITLE
Alternate work around for kernel guard pages

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -75,13 +75,6 @@
 #endif
 #ifdef __FreeBSD__
 # include <sys/sysctl.h>
-# include <sys/procctl.h>
-#ifndef PROC_STACKGAP_STATUS
-#define PROC_STACKGAP_STATUS	18
-#endif
-#ifndef PROC_STACKGAP_DISABLE
-#define PROC_STACKGAP_DISABLE	0x0002
-#endif
 #endif /* __FreeBSD__ */
 
 // needed by current_stack_region() workaround for Mavericks
@@ -520,55 +513,6 @@ JVM_handle_bsd_signal(int sig,
     // Handle ALL stack overflow variations here
     if (sig == SIGSEGV || sig == SIGBUS) {
       address addr = (address) info->si_addr;
-#ifdef __FreeBSD__
-      /*
-       * Determine whether the kernel stack guard pages have been disabled
-       */
-      int status = 0;
-      int ret = procctl(P_PID, getpid(), PROC_STACKGAP_STATUS, &status);
-
-      /*
-       * Check if the call to procctl(2) failed or the stack guard is not
-       * disabled.  Either way, we'll then attempt a workaround.
-       */
-      if (ret == -1 || !(status & PROC_STACKGAP_DISABLE)) {
-          /*
-           * Try to work around the problems caused on FreeBSD where the kernel
-           * may place guard pages above JVM guard pages and prevent the Java
-           * thread stacks growing into the JVM guard pages.  The work around
-           * is to determine how many such pages there may be and round down the
-           * fault address so that tests of whether it is in the JVM guard zone
-           * succeed.
-           *
-           * Note that this is a partial workaround at best since the normally
-           * the JVM could then unprotect the reserved area to allow a critical
-           * section to complete.  This is not possible if the kernel has
-           * placed guard pages below the reserved area.
-           *
-           * This also suffers from the problem that the
-           * security.bsd.stack_guard_page sysctl is dynamic and may have
-           * changed since the stack was allocated.  This is likely to be rare
-           * in practice though.
-           *
-           * What this does do is prevent the JVM crashing on FreeBSD and
-           * instead throwing a StackOverflowError when infinite recursion
-           * is attempted, which is the expected behaviour.  Due to it's
-           * limitations though, objects may be in unexpected states when
-           * this occurs.
-           *
-           * A better way to avoid these problems is either to be on a new
-           * enough version of FreeBSD (one that has PROC_STACKGAP_CTL) or set
-           * security.bsd.stack_guard_page to zero.
-           */
-          int guard_pages = 0;
-          size_t size = sizeof(guard_pages);
-          if (sysctlbyname("security.bsd.stack_guard_page",
-                           &guard_pages, &size, NULL, 0) == 0 &&
-              guard_pages > 0) {
-            addr -= guard_pages * os::vm_page_size();
-          }
-      }
-#endif
 
       // check if fault address is within thread stack
       if (thread->on_local_stack(addr)) {


### PR DESCRIPTION
* Don't do the address arithmetic workaround in arch specific code.
* Set the pthread guard size attribute on FreeBSD to cover the kernel
  stack guard pages, if disabling them with procctl didn't work.
* Read from the guard pages so they get paged in so that guard_memory
  will work correctly.

This review is currently for comment only.  With these changes in place the JVM crashes during the build.  I'm looking at why, but more eyes may be helpful.