### PR TITLE
Add aarch64 OpenBSD support

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -96,6 +96,10 @@ else ifeq ($(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU), linux-aarch64)
   endif
 endif
 
+ifeq ($(OPENJDK_TARGET_OS_ENV)-$(OPENJDK_TARGET_CPU), bsd.openbsd-aarch64)
+  JVM_EXCLUDE_FILES += threadLS_bsd_aarch64.s
+endif
+
 ifneq ($(filter $(OPENJDK_TARGET_OS), linux macosx bsd windows), )
   JVM_PRECOMPILED_HEADER := $(TOPDIR)/src/hotspot/share/precompiled/precompiled.hpp
 endif

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1480,7 +1480,7 @@ void MacroAssembler::movptr(Register r, uintptr_t imm64) {
 #ifndef PRODUCT
   {
     char buffer[64];
-    snprintf(buffer, sizeof(buffer), "0x%"PRIX64, imm64);
+    snprintf(buffer, sizeof(buffer), INTPTR_FORMAT, imm64);
     block_comment(buffer);
   }
 #endif
@@ -1945,7 +1945,7 @@ void MacroAssembler::decrement(Register reg, int value)
   if (value < (1 << 12)) { sub(reg, reg, value); return; }
   /* else */ {
     assert(reg != rscratch2, "invalid dst for register decrement");
-    mov(rscratch2, (unsigned long)value);
+    mov(rscratch2, (u_int64_t)value);
     sub(reg, reg, rscratch2);
   }
 }
@@ -2482,43 +2482,43 @@ void MacroAssembler::debug64(char* msg, int64_t pc, int64_t regs[])
 #endif
     if (os::message_box(msg, "Execution stopped, print registers?")) {
       ttyLocker ttyl;
-      tty->print_cr(" pc = 0x%016lx", pc);
+      tty->print_cr(" pc = 0x" UINT64_FORMAT_X, pc);
 #ifndef PRODUCT
       tty->cr();
       findpc(pc);
       tty->cr();
 #endif
-      tty->print_cr(" r0 = 0x%016lx", regs[0]);
-      tty->print_cr(" r1 = 0x%016lx", regs[1]);
-      tty->print_cr(" r2 = 0x%016lx", regs[2]);
-      tty->print_cr(" r3 = 0x%016lx", regs[3]);
-      tty->print_cr(" r4 = 0x%016lx", regs[4]);
-      tty->print_cr(" r5 = 0x%016lx", regs[5]);
-      tty->print_cr(" r6 = 0x%016lx", regs[6]);
-      tty->print_cr(" r7 = 0x%016lx", regs[7]);
-      tty->print_cr(" r8 = 0x%016lx", regs[8]);
-      tty->print_cr(" r9 = 0x%016lx", regs[9]);
-      tty->print_cr("r10 = 0x%016lx", regs[10]);
-      tty->print_cr("r11 = 0x%016lx", regs[11]);
-      tty->print_cr("r12 = 0x%016lx", regs[12]);
-      tty->print_cr("r13 = 0x%016lx", regs[13]);
-      tty->print_cr("r14 = 0x%016lx", regs[14]);
-      tty->print_cr("r15 = 0x%016lx", regs[15]);
-      tty->print_cr("r16 = 0x%016lx", regs[16]);
-      tty->print_cr("r17 = 0x%016lx", regs[17]);
-      tty->print_cr("r18 = 0x%016lx", regs[18]);
-      tty->print_cr("r19 = 0x%016lx", regs[19]);
-      tty->print_cr("r20 = 0x%016lx", regs[20]);
-      tty->print_cr("r21 = 0x%016lx", regs[21]);
-      tty->print_cr("r22 = 0x%016lx", regs[22]);
-      tty->print_cr("r23 = 0x%016lx", regs[23]);
-      tty->print_cr("r24 = 0x%016lx", regs[24]);
-      tty->print_cr("r25 = 0x%016lx", regs[25]);
-      tty->print_cr("r26 = 0x%016lx", regs[26]);
-      tty->print_cr("r27 = 0x%016lx", regs[27]);
-      tty->print_cr("r28 = 0x%016lx", regs[28]);
-      tty->print_cr("r30 = 0x%016lx", regs[30]);
-      tty->print_cr("r31 = 0x%016lx", regs[31]);
+      tty->print_cr(" r0 = 0x" UINT64_FORMAT_X, regs[0]);
+      tty->print_cr(" r1 = 0x" UINT64_FORMAT_X, regs[1]);
+      tty->print_cr(" r2 = 0x" UINT64_FORMAT_X, regs[2]);
+      tty->print_cr(" r3 = 0x" UINT64_FORMAT_X, regs[3]);
+      tty->print_cr(" r4 = 0x" UINT64_FORMAT_X, regs[4]);
+      tty->print_cr(" r5 = 0x" UINT64_FORMAT_X, regs[5]);
+      tty->print_cr(" r6 = 0x" UINT64_FORMAT_X, regs[6]);
+      tty->print_cr(" r7 = 0x" UINT64_FORMAT_X, regs[7]);
+      tty->print_cr(" r8 = 0x" UINT64_FORMAT_X, regs[8]);
+      tty->print_cr(" r9 = 0x" UINT64_FORMAT_X, regs[9]);
+      tty->print_cr("r10 = 0x" UINT64_FORMAT_X, regs[10]);
+      tty->print_cr("r11 = 0x" UINT64_FORMAT_X, regs[11]);
+      tty->print_cr("r12 = 0x" UINT64_FORMAT_X, regs[12]);
+      tty->print_cr("r13 = 0x" UINT64_FORMAT_X, regs[13]);
+      tty->print_cr("r14 = 0x" UINT64_FORMAT_X, regs[14]);
+      tty->print_cr("r15 = 0x" UINT64_FORMAT_X, regs[15]);
+      tty->print_cr("r16 = 0x" UINT64_FORMAT_X, regs[16]);
+      tty->print_cr("r17 = 0x" UINT64_FORMAT_X, regs[17]);
+      tty->print_cr("r18 = 0x" UINT64_FORMAT_X, regs[18]);
+      tty->print_cr("r19 = 0x" UINT64_FORMAT_X, regs[19]);
+      tty->print_cr("r20 = 0x" UINT64_FORMAT_X, regs[20]);
+      tty->print_cr("r21 = 0x" UINT64_FORMAT_X, regs[21]);
+      tty->print_cr("r22 = 0x" UINT64_FORMAT_X, regs[22]);
+      tty->print_cr("r23 = 0x" UINT64_FORMAT_X, regs[23]);
+      tty->print_cr("r24 = 0x" UINT64_FORMAT_X, regs[24]);
+      tty->print_cr("r25 = 0x" UINT64_FORMAT_X, regs[25]);
+      tty->print_cr("r26 = 0x" UINT64_FORMAT_X, regs[26]);
+      tty->print_cr("r27 = 0x" UINT64_FORMAT_X, regs[27]);
+      tty->print_cr("r28 = 0x" UINT64_FORMAT_X, regs[28]);
+      tty->print_cr("r30 = 0x" UINT64_FORMAT_X, regs[30]);
+      tty->print_cr("r31 = 0x" UINT64_FORMAT_X, regs[31]);
       BREAKPOINT;
     }
     ThreadStateTransition::transition(thread, _thread_in_vm, saved_state);
@@ -5030,7 +5030,7 @@ void MacroAssembler::has_negatives(Register ary1, Register len, Register result)
 
     int shift = 64 - exact_log2(os::vm_page_size());
     lsl(rscratch1, ary1, shift);
-    mov(rscratch2, (size_t)(4 * wordSize) << shift);
+    mov(rscratch2, (u_int64_t)(4 * wordSize) << shift);
     adds(rscratch2, rscratch1, rscratch2);  // At end of page?
     br(CS, STUB); // at the end of page then go to stub
     subs(len, len, wordSize);
@@ -5761,6 +5761,22 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
   csel(result, result, zr, EQ);
 }
 
+#ifdef __OpenBSD__
+// OpenBSD uses emulated tls so it can't use aarch64_get_thread_helper().
+// Save whatever non-callee save context might get clobbered by
+// Thread::current.
+void MacroAssembler::get_thread(Register dst) {
+  RegSet saved_regs = RegSet::range(r0, r18) + lr - dst;
+  push(saved_regs, sp);
+
+  MacroAssembler::call_VM_leaf_base(CAST_FROM_FN_PTR(address, Thread::current), 0);
+  if (dst != c_rarg0) {
+    mov(dst, c_rarg0);
+  }
+
+  pop(saved_regs, sp);
+}
+#else
 // get_thread() can be called anywhere inside generated code so we
 // need to save whatever non-callee save context might get clobbered
 // by the call to JavaThread::aarch64_get_thread_helper() or, indeed,
@@ -5780,3 +5796,4 @@ void MacroAssembler::get_thread(Register dst) {
 
   pop(saved_regs, sp);
 }
+#endif

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -88,7 +88,7 @@ class MacroAssembler: public Assembler {
       = (operand_valid_for_logical_immediate(false /*is32*/,
                                              (uint64_t)Universe::narrow_klass_base())
          && ((uint64_t)Universe::narrow_klass_base()
-             > (1UL << log2_intptr(Universe::narrow_klass_range()))));
+             > (1UL << log2_intptr((uintptr_t)Universe::narrow_klass_range()))));
   }
 
  // These routines should emit JVMTI PopFrame and ForceEarlyReturn handling code.

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
@@ -297,7 +297,7 @@ void MacroAssembler::fast_log(FloatRegister vtmp0, FloatRegister vtmp1,
   bind(MAIN);
     fmovs(tmp3, vtmp5);                        // int intB0 = AS_INT_BITS(B);
     mov(tmp5, 0x3FE0);
-    mov(rscratch1, 0xffffe00000000000);
+    mov(rscratch1, (u_int64_t)0xffffe00000000000);
     andr(tmp2, tmp2, tmp1, LSR, 48);           // hiWord & 0x7FF0
     sub(tmp2, tmp2, tmp5);                     // tmp2 = hiWord & 0x7FF0 - 0x3FE0
     scvtfwd(vtmp5, tmp2);                      // vtmp5 = (double)tmp2;

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -429,7 +429,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
           __ str(rscratch1, Address(sp, next_off));
 #ifdef ASSERT
           // Overwrite the unused slot with known junk
-          __ mov(rscratch1, 0xdeadffffdeadaaaaul);
+          __ mov(rscratch1, (u_int64_t)0xdeadffffdeadaaaaul);
           __ str(rscratch1, Address(sp, st_off));
 #endif /* ASSERT */
         } else {
@@ -449,7 +449,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
           // long/double in gpr
 #ifdef ASSERT
           // Overwrite the unused slot with known junk
-          __ mov(rscratch1, 0xdeadffffdeadaaabul);
+          __ mov(rscratch1, (u_int64_t)0xdeadffffdeadaaabul);
           __ str(rscratch1, Address(sp, st_off));
 #endif /* ASSERT */
           __ str(r, Address(sp, next_off));
@@ -465,7 +465,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
       } else {
 #ifdef ASSERT
         // Overwrite the unused slot with known junk
-        __ mov(rscratch1, 0xdeadffffdeadaaacul);
+        __ mov(rscratch1, (u_int64_t)0xdeadffffdeadaaacul);
         __ str(rscratch1, Address(sp, st_off));
 #endif /* ASSERT */
         __ strd(r_1->as_FloatRegister(), Address(sp, next_off));

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3215,8 +3215,8 @@ class StubGenerator: public StubCodeGenerator {
 
     // Max number of bytes we can process before having to take the mod
     // 0x15B0 is 5552 in decimal, the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
-    unsigned long BASE = 0xfff1;
-    unsigned long NMAX = 0x15B0;
+    u_int64_t BASE = 0xfff1;
+    u_int64_t NMAX = 0x15B0;
 
     __ mov(base, BASE);
     __ mov(nmax, NMAX);

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -195,7 +195,7 @@ void VM_Version::get_processor_features() {
     }
     fclose(f);
   }
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
   char buf[512];
   int cpu_lines = 0;
   unsigned long auxv = os_get_processor_features();

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -47,7 +47,7 @@ protected:
   };
   static PsrInfo _psr_info;
   static void get_processor_features();
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
   static unsigned long os_get_processor_features();
 #endif
 

--- a/src/hotspot/os_cpu/bsd_aarch64/bytes_bsd_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/bytes_bsd_aarch64.inline.hpp
@@ -26,9 +26,15 @@
 #ifndef OS_CPU_BSD_AARCH64_VM_BYTES_BSD_AARCH64_INLINE_HPP
 #define OS_CPU_BSD_AARCH64_VM_BYTES_BSD_AARCH64_INLINE_HPP
 
-#define bswap_16(x) __bswap16(x)
-#define bswap_32(x) __bswap32(x)
-#define bswap_64(x) __bswap64(x)
+#if defined(__FreeBSD__)
+#  define bswap_16(x) __bswap16(x)
+#  define bswap_32(x) __bswap32(x)
+#  define bswap_64(x) __bswap64(x)
+#elif defined(__OpenBSD__)
+#  define bswap_16(x) swap16(x)
+#  define bswap_32(x) swap32(x)
+#  define bswap_64(x) swap64(x)
+#endif
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -72,8 +72,8 @@
 # include <sys/wait.h>
 # include <pwd.h>
 # include <poll.h>
-# include <ucontext.h>
 #ifdef __FreeBSD__
+# include <ucontext.h>
 # include <sys/sysctl.h>
 # include <sys/procctl.h>
 # ifndef PROC_STACKGAP_STATUS
@@ -85,7 +85,6 @@
 #endif /* __FreeBSD__ */
 
 #define REG_FP 29
-#define REG_LR 30
 
 NOINLINE address os::current_stack_pointer() {
   return (address)__builtin_frame_address(0);
@@ -100,19 +99,35 @@ char* os::non_memory_address_word() {
 }
 
 address os::Bsd::ucontext_get_pc(const ucontext_t * uc) {
+#if defined(__FreeBSD__)
   return (address)uc->uc_mcontext.mc_gpregs.gp_elr;
+#elif defined(__OpenBSD__)
+  return (address)uc->sc_elr;
+#endif
 }
 
 void os::Bsd::ucontext_set_pc(ucontext_t * uc, address pc) {
+#if defined(__FreeBSD__)
   uc->uc_mcontext.mc_gpregs.gp_elr = (intptr_t)pc;
+#elif defined(__OpenBSD__)
+  uc->sc_elr = (unsigned long)pc;
+#endif
 }
 
 intptr_t* os::Bsd::ucontext_get_sp(const ucontext_t * uc) {
+#if defined(__FreeBSD__)
   return (intptr_t*)uc->uc_mcontext.mc_gpregs.gp_sp;
+#elif defined(__OpenBSD__)
+  return (intptr_t*)uc->sc_sp;
+#endif
 }
 
 intptr_t* os::Bsd::ucontext_get_fp(const ucontext_t * uc) {
+#if defined(__FreeBSD__)
   return (intptr_t*)uc->uc_mcontext.mc_gpregs.gp_x[REG_FP];
+#elif defined(__OpenBSD__)
+  return (intptr_t*)uc->sc_x[REG_FP];
+#endif
 }
 
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread
@@ -183,8 +198,13 @@ bool os::Bsd::get_frame_at_stack_banging_point(JavaThread* thread, ucontext_t* u
       // belong to the caller.
       intptr_t* fp = os::Bsd::ucontext_get_fp(uc);
       intptr_t* sp = os::Bsd::ucontext_get_sp(uc);
+#if defined(__FreeBSD__)
       address pc = (address)(uc->uc_mcontext.mc_gpregs.gp_lr
                          - NativeInstruction::instruction_size);
+#elif defined(__OpenBSD__)
+      address pc = (address)(uc->sc_lr
+                         - NativeInstruction::instruction_size);
+#endif
       *fr = frame(sp, fp, pc);
       if (!fr->is_java_frame()) {
         assert(fr->safe_for_sender(thread), "Safety check");
@@ -528,7 +548,11 @@ void os::print_context(outputStream *st, const void *context) {
   st->print_cr("Registers:");
   for (int r = 0; r < 30; r++) {
     st->print("R%-2d=", r);
+#if defined(__FreeBSD__)
     print_location(st, uc->uc_mcontext.mc_gpregs.gp_x[r]);
+#elif defined(__OpenBSD__)
+    print_location(st, uc->sc_x[r]);
+#endif
   }
   st->cr();
 
@@ -560,7 +584,11 @@ void os::print_register_info(outputStream *st, const void *context) {
   // this is only for the "general purpose" registers
 
   for (int r = 0; r < 30; r++)
+#if defined(__FreeBSD__)
     st->print_cr(  "R%d=" INTPTR_FORMAT, r, (uintptr_t)uc->uc_mcontext.mc_gpregs.gp_x[r]);
+#elif defined(__OpenBSD__)
+    st->print_cr(  "R%d=" INTPTR_FORMAT, r, (uintptr_t)uc->sc_x[r]);
+#endif
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -27,8 +27,8 @@
 #include "runtime/os.hpp"
 #include "vm_version_aarch64.hpp"
 
-#if defined (__FreeBSD__)
 #include <machine/armreg.h>
+#if defined (__FreeBSD__)
 #include <machine/elf.h>
 #endif
 
@@ -186,6 +186,17 @@ const struct cpu_implementers cpu_implementers[] = {
 	CPU_IMPLEMENTER_NONE,
 };
 
+#ifdef __OpenBSD__
+// READ_SPECIALREG is not available from userland on OpenBSD.
+// Hardcode these values to the "lowest common denominator"
+unsigned long VM_Version::os_get_processor_features() {
+  _cpu = CPU_IMPL_ARM;
+  _model = CPU_PART_CORTEX_A53;
+  _variant = 0;
+  _revision = 0;
+  return HWCAP_ASIMD;
+}
+#else
 unsigned long VM_Version::os_get_processor_features() {
   struct cpu_desc cpu_desc[1];
   struct cpu_desc user_cpu_desc;
@@ -259,3 +270,4 @@ unsigned long VM_Version::os_get_processor_features() {
 
   return auxv;
 }
+#endif


### PR DESCRIPTION
Notable items:
* OpenBSD uses emulated tls so exclude optimized get_thread in
  threadLS_bsd_aarch64.s and provide slower implementation for
  OpenBSD.
* OpenBSD uses unsigned long long for u_int64_t instead of
  unsigned long which prevents implicit conversions currently
  in use. Adjust to correct datatypes and format specifiers
  as needed.
* READ_SPECIALREG called from userland on OpenBSD raises
  SIGILL/ILL_ILLOPC signal. Disable cpu detection and
  processor features for now on OpenBSD.