### PR TITLE
<sys/user.h> was removed from NetBSD

### DIFF
--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -34,7 +34,9 @@
   #include <mach/mach.h>
   #include <mach/task_info.h>
 #else
-  #include <sys/user.h>
+  #ifndef __NetBSD__
+    #include <sys/user.h>
+  #endif
   #include <sys/sched.h>
   #include <sys/resource.h>
   #define NET_RT_IFLIST2 NET_RT_IFLIST

--- a/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
@@ -29,7 +29,9 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
-#include <sys/user.h>
+#ifndef __NetBSD__
+  #include <sys/user.h>
+#endif
 #include <unistd.h>
 
 #include "jvm.h"


### PR DESCRIPTION
NetBSD no longer ships <sys/user.h>. See:
http://mail-index.netbsd.org/tech-userlevel/2017/06/10/msg010630.html

I have verified that omitting inclusion of <sys/user.h> does not cause problem on older NetBSD releases.