### PR TITLE
NetBSD's pthread_setname_np() has the following prototype

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -3650,7 +3650,7 @@ void os::set_native_thread_name(const char *name) {
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
     pthread_set_name_np(pthread_self(), name);
 #elif defined(__NetBSD__)
-    pthread_setname_np(pthread_self(), "%s", name);
+    pthread_setname_np(pthread_self(), "%s", const_cast<char *>(name));
 #endif
   }
 }


### PR DESCRIPTION
int pthread_setname_np(pthread_t thread, const char *name, void *arg);
arg is not const.