### PR TITLE
NetBSD's sigaction symbol is __sigaction14

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -3395,7 +3395,11 @@ void os::Bsd::check_signal_handler(int sig) {
   struct sigaction act;
   if (os_sigaction == NULL) {
     // only trust the default sigaction, in case it has been interposed
+#if defined(__NetBSD__)
+    os_sigaction = (os_sigaction_t)dlsym(RTLD_DEFAULT, "__sigaction14");
+#else
     os_sigaction = (os_sigaction_t)dlsym(RTLD_DEFAULT, "sigaction");
+#endif
     if (os_sigaction == NULL) return;
   }
 


### PR DESCRIPTION
NetBSD's compat layer renames sigaction to __sigaction14.
Fix Japanese input in swing UI and other sigaction related behaviors.