### PR TITLE
Enable Java Sound support with ALSA on NetBSD

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -73,7 +73,7 @@ AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
   fi
 
   # Check if alsa is needed
-  if test "x$OPENJDK_TARGET_OS" = xlinux -o "x$OPENJDK_TARGET_OS_ENV" = xbsd.freebsd; then
+  if test "x$OPENJDK_TARGET_OS" = xlinux -o "x$OPENJDK_TARGET_OS_ENV" = xbsd.freebsd -o "x$OPENJDK_TARGET_OS_ENV" = xbsd.netbsd; then
     NEEDS_LIB_ALSA=true
   else
     NEEDS_LIB_ALSA=false

--- a/make/lib/Lib-java.desktop.gmk
+++ b/make/lib/Lib-java.desktop.gmk
@@ -67,10 +67,6 @@ ifneq ($(OPENJDK_TARGET_OS), aix)
     LIBJSOUND_EXCLUDE_SRC_PATTERNS := bsd
   endif
 
-  ifeq ($(OPENJDK_TARGET_OS_ENV), bsd.netbsd)
-    LIBJSOUND_EXCLUDE_SRC_PATTERNS := bsd
-  endif
-
   $(eval $(call SetupJdkLibrary, BUILD_LIBJSOUND, \
       NAME := jsound, \
       EXCLUDE_SRC_PATTERNS := $(LIBJSOUND_EXCLUDE_SRC_PATTERNS), \

--- a/src/java.desktop/bsd/native/libjsound/PLATFORM_API_BsdOS_ALSA_PCM.c
+++ b/src/java.desktop/bsd/native/libjsound/PLATFORM_API_BsdOS_ALSA_PCM.c
@@ -32,6 +32,10 @@
 
 #if USE_DAUDIO == TRUE
 
+#ifndef ESTRPIPE
+#    define ESTRPIPE EPIPE
+#endif
+
 // GetPosition method 1: based on how many bytes are passed to the kernel driver
 //                       + does not need much processor resources
 //                       - not very exact, "jumps"


### PR DESCRIPTION
Java Sound support by userland ALSA library works under NetBSD.
Please enable ALSA for NetBSD.