### PR TITLE
FreeBSD implementation of getSingleCpuLoad0 and getHostConfiguredCpuCount0

### DIFF
--- a/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
@@ -33,49 +33,112 @@
   #include <sys/user.h>
 #endif
 #include <unistd.h>
+#ifdef __FreeBSD__
+  #include <stdlib.h>
+  #include <malloc_np.h>
+#endif
 
 #include "jvm.h"
+
+struct ticks {
+    jlong used;
+    jlong total;
+};
+
+typedef struct ticks ticks;
+
+static struct perfbuf {
+    int   nProcs;
+    ticks jvmTicks;
+    ticks cpuTicks;
+    ticks *cpus;
+} counters;
+
+/**
+ * This method must be called first, before any data can be gathererd.
+ */
+int perfInit() {
+    static int initialized = 0;
+
+    if (!initialized) {
+        int mib[2];
+        size_t len;
+        int cpu_val;
+
+        mib[0] = CTL_HW;
+        mib[1] = HW_NCPU;
+        len = sizeof(cpu_val);
+        if (sysctl(mib, 2, &cpu_val, &len, NULL, 0) == -1 || cpu_val < 1) {
+            cpu_val = 1;
+        }
+
+        counters.nProcs = cpu_val;
+#ifdef __FreeBSD__
+        // Initialise JVM
+        counters.jvmTicks.used  = 0;
+        counters.jvmTicks.total = 0;
+
+        // Initialise CPU
+        counters.cpuTicks.used  = 0;
+        counters.cpuTicks.total = 0;
+
+        counters.cpus = calloc(cpu_val, sizeof(ticks));
+        if (counters.cpus != NULL) {
+            // Initialise per CPU
+            for (int i = 0; i < counters.nProcs; i++) {
+                counters.cpus[i].used = 0;
+                counters.cpus[i].total = 0;
+            }
+        }
+#endif
+        initialized = 1;
+    }
+
+    return initialized ? 0 : -1;
+}
 
 JNIEXPORT jdouble JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getSystemCpuLoad0
 (JNIEnv *env, jobject dummy)
 {
 #ifdef __FreeBSD__
-    /* This is based on the MacOS X implementation */
+    if (perfInit() == 0) {
+        /* This is based on the MacOS X implementation */
 
-    static jlong last_used  = 0;
-    static jlong last_total = 0;
+        /* Load CPU times */
+        long cp_time[CPUSTATES];
+        size_t len = sizeof(cp_time);
+        if (sysctlbyname("kern.cp_time", &cp_time, &len, NULL, 0) == -1) {
+            return -1.;
+        }
 
-    /* Load CPU times */
-    long cp_time[CPUSTATES];
-    size_t len = sizeof(cp_time);
-    if (sysctlbyname("kern.cp_time", &cp_time, &len, NULL, 0) == -1) {
-        return -1.;
+        jlong used  = cp_time[CP_USER] + cp_time[CP_NICE] + cp_time[CP_SYS] + cp_time[CP_INTR];
+        jlong total = used + cp_time[CP_IDLE];
+
+        if (counters.cpuTicks.used == 0 || counters.cpuTicks.total == 0) {
+            // First call, just set the last values
+            counters.cpuTicks.used = used;
+            counters.cpuTicks.total = total;
+            // return 0 since we have no data, not -1 which indicates error
+            return 0.;
+        }
+
+        jlong used_delta  = used - counters.cpuTicks.used;
+        jlong total_delta = total - counters.cpuTicks.total;
+
+        jdouble cpu = (jdouble) used_delta / total_delta;
+
+        counters.cpuTicks.used = used;
+        counters.cpuTicks.total = total;
+
+        return cpu;
     }
-
-    jlong used  = cp_time[CP_USER] + cp_time[CP_NICE] + cp_time[CP_SYS] + cp_time[CP_INTR];
-    jlong total = used + cp_time[CP_IDLE];
-
-    if (last_used == 0 || last_total == 0) {
-        // First call, just set the last values
-        last_used  = used;
-        last_total = total;
-        // return 0 since we have no data, not -1 which indicates error
-        return 0.;
-    }
-
-    jlong used_delta  = used - last_used;
-    jlong total_delta = total - last_total;
-
-    jdouble cpu = (jdouble) used_delta / total_delta;
-
-    last_used  = used;
-    last_total = total;
-
-    return cpu;
-#else
+    else {
+#endif
     // Not implemented yet
     return -1.;
+#ifdef __FreeBSD__
+    }
 #endif
 }
 
@@ -95,57 +158,59 @@ Java_com_sun_management_internal_OperatingSystemImpl_getProcessCpuLoad0
 (JNIEnv *env, jobject dummy)
 {
 #ifdef __FreeBSD__
-    /* This is based on the MacOS X implementation */
+    if (perfInit() == 0) {
+        /* This is based on the MacOS X implementation */
 
-    static jlong last_task_time = 0;
-    static jlong last_time      = 0;
+        struct timeval now;
+        struct kinfo_proc kp;
+        int mib[4];
+        size_t len = sizeof(struct kinfo_proc);
 
-    struct timeval now;
-    struct kinfo_proc kp;
-    int mib[4];
-    size_t len = sizeof(struct kinfo_proc);
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_PROC;
+        mib[2] = KERN_PROC_PID;
+        mib[3] = getpid();
 
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = getpid();
+        if (sysctl(mib, 4, &kp, &len, NULL, 0) == -1) {
+            return -1.;
+        }
 
-    if (sysctl(mib, 4, &kp, &len, NULL, 0) == -1) {
-        return -1.;
+        if (gettimeofday(&now, NULL) == -1) {
+            return -1.;
+        }
+
+        jint ncpus      = JVM_ActiveProcessorCount();
+        jlong time      = TIME_VALUE_TO_MICROSECONDS(now) * ncpus;
+        jlong task_time = TIME_VALUE_TO_MICROSECONDS(kp.ki_rusage.ru_utime) +
+                          TIME_VALUE_TO_MICROSECONDS(kp.ki_rusage.ru_stime);
+
+        if (counters.jvmTicks.used == 0 || counters.jvmTicks.total == 0) {
+            // First call, just set the last values.
+            counters.jvmTicks.used  = task_time;
+            counters.jvmTicks.total = time;
+            // return 0 since we have no data, not -1 which indicates error
+            return 0.;
+        }
+
+        jlong task_time_delta = task_time - counters.jvmTicks.used;
+        jlong time_delta      = time - counters.jvmTicks.total;
+        if (time_delta == 0) {
+            return -1.;
+        }
+
+        jdouble cpu = (jdouble) task_time_delta / time_delta;
+
+        counters.jvmTicks.used  = task_time;
+        counters.jvmTicks.total = time;
+
+        return cpu;
     }
-
-    if (gettimeofday(&now, NULL) == -1) {
-        return -1.;
-    }
-
-    jint ncpus      = JVM_ActiveProcessorCount();
-    jlong time      = TIME_VALUE_TO_MICROSECONDS(now) * ncpus;
-    jlong task_time = TIME_VALUE_TO_MICROSECONDS(kp.ki_rusage.ru_utime) +
-                      TIME_VALUE_TO_MICROSECONDS(kp.ki_rusage.ru_stime);
-
-    if ((last_task_time == 0) || (last_time == 0)) {
-        // First call, just set the last values.
-        last_task_time = task_time;
-        last_time      = time;
-        // return 0 since we have no data, not -1 which indicates error
-        return 0.;
-    }
-
-    jlong task_time_delta = task_time - last_task_time;
-    jlong time_delta      = time - last_time;
-    if (time_delta == 0) {
-        return -1.;
-    }
-
-    jdouble cpu = (jdouble) task_time_delta / time_delta;
-
-    last_task_time = task_time;
-    last_time      = time;
-
-    return cpu;
-#else
+    else {
+#endif
     // Not implemented yet
-    return -1.;
+    return -1.0;
+#ifdef __FreeBSD__
+    }
 #endif
 }
 
@@ -153,12 +218,53 @@ JNIEXPORT jdouble JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
 (JNIEnv *env, jobject dummy, jint cpu_number)
 {
+#ifdef __FreeBSD__
+    if (perfInit() == 0 && 0 <= cpu_number && cpu_number < counters.nProcs) {
+        /* Load CPU times */
+        long cp_times[CPUSTATES * counters.nProcs];
+        size_t len = sizeof(cp_times);
+        if (sysctlbyname("kern.cp_times", &cp_times, &len, NULL, 0) == -1) {
+            return -1.;
+        }
+
+        size_t offset = cpu_number * CPUSTATES;
+        jlong used  = cp_times[offset + CP_USER] + cp_times[offset + CP_NICE] + cp_times[offset + CP_SYS] + cp_times[offset + CP_INTR];
+        jlong total = used + cp_times[offset + CP_IDLE];
+
+        if (counters.cpus[cpu_number].used == 0 || counters.cpus[cpu_number].total == 0) {
+            // First call, just set the last values
+            counters.cpus[cpu_number].used  = used;
+            counters.cpus[cpu_number].total = total;
+            // return 0 since we have no data, not -1 which indicates error
+            return 0.;
+        }
+
+        jlong used_delta  = used - counters.cpus[cpu_number].used;
+        jlong total_delta = total - counters.cpus[cpu_number].total;
+
+        jdouble cpu = (jdouble) used_delta / total_delta;
+
+        counters.cpus[cpu_number].used  = used;
+        counters.cpus[cpu_number].total = total;
+
+        return cpu;
+    }
+    else {
+#endif
     return -1.0;
+#ifdef __FreeBSD__
+    }
+#endif
 }
 
 JNIEXPORT jint JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
 (JNIEnv *env, jobject mbean)
 {
-    return -1;
+    if (perfInit() == 0) {
+        return counters.nProcs;
+    }
+    else {
+        return -1;
+    }
 }


### PR DESCRIPTION
* Make this a little closer to the Linux implementation by storing the overall state for the file in a struct rather than individually in each function as well as introducing a single initialisation function.
* Add an implementation of getSingleCpuLoad0 and getHostConfiguredCpuCount0 for FreeBSD
* #ifdef out FreeBSD only sections

Testing:

* Builds on FreeBSD
* Connecting with jconsole appears to show reasonable data for a process, including the correct number of processors.  I couldn't find the section for individual CPU load